### PR TITLE
ECAL selection and Calc Button for Mixer Frequency setup

### DIFF
--- a/OpenTap.Plugins.PNAX/Instrument/PNA.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNA.cs
@@ -38,6 +38,8 @@ namespace OpenTap.Plugins.PNAX
 
         public GeneralGainCompressionPowerValues DefaultGeneralGainCompressionPowerValues;
 
+        private bool IsModelA = false;
+
         public PNAX()
         {
             Name = "PNA-X";
@@ -70,11 +72,12 @@ namespace OpenTap.Plugins.PNAX
                 WaitForOperationComplete();
             }
 
-            //if (!IdnString.Contains("Instrument ID"))
-            //{
-            //    Log.Error("This instrument driver does not support the connected instrument.");
-            //    throw new ArgumentException("Wrong instrument type.");
-            // }
+            String[] IDNValues = IdnString.Split(',');
+            if (IDNValues[1].StartsWith("N") && IDNValues[1].EndsWith("A"))
+            {
+                // We have a PNA instrument from the A family i.e. N5235A
+                IsModelA = true;
+            }
 
             mnum = 1;
         }

--- a/OpenTap.Plugins.PNAX/Instrument/PNACal.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNACal.cs
@@ -272,6 +272,11 @@ namespace OpenTap.Plugins.PNAX
 
         public void CalAllSetProperty(String prop, String value)
         {
+            if (prop.Equals("Use Smart Cal Order") && IsModelA)
+            {
+                // A model does not support this property
+                return;
+            }
             ScpiCommand($"SYSTem:CALibrate:ALL:MCLass:PROPerty:VALue \"{prop}\",\"{value}\"");
         }
 
@@ -282,12 +287,30 @@ namespace OpenTap.Plugins.PNAX
 
         public void CalAllSelectCalKit(int Channel, int Port, String CalKit)
         {
-            ScpiCommand($"SENSe{Channel}:CORRection:COLLect:GUIDed:CKIT:PORT{Port}:SELect \"{CalKit}\"");
+            if (IsModelA)
+            {
+                ScpiCommand($"SENSe{Channel}:CORRection:COLLect:GUIDed:CKIT:PORT{Port} \"{CalKit}\"");
+            }
+            else
+            {
+                ScpiCommand($"SENSe{Channel}:CORRection:COLLect:GUIDed:CKIT:PORT{Port}:SELect \"{CalKit}\"");
+            }
+        }
+
+        public String CalAllGetCalKits(int Channel, DUTConnectorsEnum connector)
+        {
+            string conn = Scpi.Format("{0}", connector);
+            return ScpiQuery($"SENSe{Channel}:CORRection:COLLect:GUIDed:CKIT:CATalog? \"{conn}\"");
         }
 
         public int CalAllGuidedChannelNumber()
         {
+            if (IsModelA)
+            {
+                return ScpiQuery<int>($"SYSTem:CALibrate:ALL:GUIDed:CHANnel?");
+            }
             return ScpiQuery<int>($"SYSTem:CALibrate:ALL:GUIDed:CHANnel:VALue?");
+
         }
 
         public void CalAllInit(int CalChannel, String CalSetName = "", bool MatchCalSettings = false, CalModeEnum calMode = CalModeEnum.ASYN)

--- a/OpenTap.Plugins.PNAX/Instrument/PNAConverters.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNAConverters.cs
@@ -353,9 +353,19 @@ namespace OpenTap.Plugins.PNAX
             ScpiCommand($"SENSe{ Channel }:MIXer:CALCulate BOTH");
         }
 
+        public void MixerCalc(int Channel, string Calc)
+        {
+            ScpiCommand($"SENSe{ Channel }:MIXer:CALCulate {Calc}");
+        }
+
         public void MixerApply(int Channel)
         {
             ScpiCommand($"SENSe{ Channel }:MIXer:APPLY");
+        }
+
+        public void MixerDiscard(int Channel)
+        {
+            ScpiCommand($"SENSe{ Channel }:MIXer:DISCard");
         }
 
         public string GetMixerFrequencyInputMode(int Channel)
@@ -363,9 +373,10 @@ namespace OpenTap.Plugins.PNAX
             return ScpiQuery($"SENSe{ Channel }:MIXer:INPut:FREQuency:MODE?");
         }
 
-        public void SetMixerFrequencyInputMode(int Channel, string mode)
+        public void SetMixerFrequencyInputMode(int Channel, MixerFrequencyTypeEnum mode)
         {
-            ScpiCommand($"SENSe{ Channel }:MIXer:INPut:FREQuency:MODE {mode}");
+            String modeScpi = Scpi.Format("{0}", mode);
+            ScpiCommand($"SENSe{ Channel }:MIXer:INPut:FREQuency:MODE {modeScpi}");
         }
 
         public void ValidateMixerFrequencyInputMode(int Channel, string mode)
@@ -428,9 +439,10 @@ namespace OpenTap.Plugins.PNAX
             return ScpiQuery($"SENSe{ Channel }:MIXer:LO{ stage }:FREQuency:MODE?");
         }
 
-        public void SetMixerFrequencyLOMode(int Channel, int stage, String mode)
+        public void SetMixerFrequencyLOMode(int Channel, int stage, MixerFrequencyTypeEnum mode)
         {
-            ScpiCommand($"SENSe{Channel.ToString()}:MIXer:LO{stage.ToString()}:FREQuency:MODE {mode}");
+            String modeScpi = Scpi.Format("{0}", mode);
+            ScpiCommand($"SENSe{Channel.ToString()}:MIXer:LO{stage.ToString()}:FREQuency:MODE {modeScpi}");
         }
         public void ValidateMixerFrequencyLOMode(int Channel, int stage, String mode)
         {
@@ -590,6 +602,17 @@ namespace OpenTap.Plugins.PNAX
         {
             SidebandTypeEnum value = GetFrequencyIFSideband(Channel);
             if (sideband != value) throw new Exception($"ValidateFrequencyIFSideband Mismatch\nTest Step Setting: {value.ToString()}\nInstrument value: {sideband.ToString()}");
+        }
+
+        public string GetMixerFrequencyOutputMode(int Channel)
+        {
+            return ScpiQuery($"SENSe{ Channel }:MIXer:OUTPut:FREQuency:MODE?");
+        }
+
+        public void SetMixerFrequencyOutputMode(int Channel, MixerFrequencyTypeEnum mode)
+        {
+            String modeScpi = Scpi.Format("{0}", mode);
+            ScpiCommand($"SENSe{ Channel }:MIXer:OUTPut:FREQuency:MODE {modeScpi}");
         }
 
         public double GetFrequencyOutputStart(int Channel)


### PR DESCRIPTION
Close #33 
Close #43 
Close #42 

Detecting if instrument IDN starts with N and ends with A, there are a few calibration scpi commands that change between A and B models

Adding CalKit query button to Cal All Test Step
![image](https://github.com/opentap/Network-Analyzer/assets/101351788/c187ebdd-677a-4e69-ab9b-ef4781cc8a58)

Presenting the options from this query in a new dialog so the user can choose one of them 
![image](https://github.com/opentap/Network-Analyzer/assets/101351788/c19ac99a-27f7-4971-963a-8576df52d003)


Added CALC Input, LO1, LO2 and Output buttons to Mixer Frequency

![image](https://github.com/opentap/Network-Analyzer/assets/101351788/24e321dd-fab1-4ff1-9ea3-688642f147b2)
