### PR TITLE
Fix Set Port LO for converters

### DIFF
--- a/OpenTap.Plugins.PNAX/Converters/Common Steps/MixerSetupTestStep.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Common Steps/MixerSetupTestStep.cs
@@ -281,6 +281,7 @@ namespace OpenTap.Plugins.PNAX
                 PNAX.SetTuningTolerance(Channel, Tolerance);
                 PNAX.SetLOFrequencyDelta(Channel, LOFrequencyDelta);
             }
+            PNAX.MixerApply(Channel);
 
             UpgradeVerdict(Verdict.Pass);
         }

--- a/OpenTap.Plugins.PNAX/Converters/Gain Compression/GainCompressionChannel.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Gain Compression/GainCompressionChannel.cs
@@ -40,12 +40,12 @@ namespace OpenTap.Plugins.PNAX
             // Traces
             GainCompressionNewTrace gainCompressionNewTrace = new GainCompressionNewTrace { IsControlledByParent = true, Channel = this.Channel, ConverterStages = this.ConverterStages };
 
-            this.ChildTestSteps.Add(mixerSetupTestStep);
-            this.ChildTestSteps.Add(mixerPowerTestStep);
-            this.ChildTestSteps.Add(mixerFrequencyTestStep);
-            this.ChildTestSteps.Add(compression);
-            this.ChildTestSteps.Add(power);
             this.ChildTestSteps.Add(frequency);
+            this.ChildTestSteps.Add(power);
+            this.ChildTestSteps.Add(compression);
+            this.ChildTestSteps.Add(mixerFrequencyTestStep);
+            this.ChildTestSteps.Add(mixerPowerTestStep);
+            this.ChildTestSteps.Add(mixerSetupTestStep);
             this.ChildTestSteps.Add(gainCompressionNewTrace);
 
             // Once we have all child steps, lets get the number of points

--- a/OpenTap.Plugins.PNAX/Converters/Noise Figure/NoiseFigureChannel.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Noise Figure/NoiseFigureChannel.cs
@@ -38,12 +38,12 @@ namespace OpenTap.Plugins.PNAX
             // Trace
             NoiseFigureNewTrace noiseFigureNewTrace = new NoiseFigureNewTrace { IsControlledByParent = true, Channel = this.Channel, ConverterStages = this.ConverterStages };
 
-            this.ChildTestSteps.Add(mixerSetupTestStep);
-            this.ChildTestSteps.Add(mixerPowerTestStep);
-            this.ChildTestSteps.Add(mixerFrequencyTestStep);
-            this.ChildTestSteps.Add(noiseFigure);
-            this.ChildTestSteps.Add(power);
             this.ChildTestSteps.Add(frequency);
+            this.ChildTestSteps.Add(power);
+            this.ChildTestSteps.Add(noiseFigure);
+            this.ChildTestSteps.Add(mixerFrequencyTestStep);
+            this.ChildTestSteps.Add(mixerPowerTestStep);
+            this.ChildTestSteps.Add(mixerSetupTestStep);
             this.ChildTestSteps.Add(noiseFigureNewTrace);
 
             // Once we have all child steps, lets get the number of points

--- a/OpenTap.Plugins.PNAX/Converters/Scalar Mixer Phase/ScalarMixerChannel.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Scalar Mixer Phase/ScalarMixerChannel.cs
@@ -61,11 +61,11 @@ namespace OpenTap.Plugins.PNAX
             mixerPowerTestStep.LO2SweptPowerStop = 0.0;
             mixerPowerTestStep.LO2SweptPowerStep = 0.050;
 
-            this.ChildTestSteps.Add(mixerSetupTestStep);
-            this.ChildTestSteps.Add(mixerPowerTestStep);
-            this.ChildTestSteps.Add(mixerFrequencyTestStep);
-            this.ChildTestSteps.Add(scalerMixerPower);
             this.ChildTestSteps.Add(scalerMixerSweep);
+            this.ChildTestSteps.Add(scalerMixerPower);
+            this.ChildTestSteps.Add(mixerFrequencyTestStep);
+            this.ChildTestSteps.Add(mixerPowerTestStep);
+            this.ChildTestSteps.Add(mixerSetupTestStep);
             this.ChildTestSteps.Add(scalarMixerNewTrace);
 
             // Once we have all child steps, lets get the number of points

--- a/OpenTap.Plugins.PNAX/Converters/SweptIMD/SweptIMDChannel.cs
+++ b/OpenTap.Plugins.PNAX/Converters/SweptIMD/SweptIMDChannel.cs
@@ -71,11 +71,11 @@ namespace OpenTap.Plugins.PNAX
 
 
 
-            this.ChildTestSteps.Add(mixerSetupTestStep);
-            this.ChildTestSteps.Add(mixerPowerTestStep);
-            this.ChildTestSteps.Add(mixerFrequencyTestStep);
-            this.ChildTestSteps.Add(power);
             this.ChildTestSteps.Add(frequency);
+            this.ChildTestSteps.Add(power);
+            this.ChildTestSteps.Add(mixerFrequencyTestStep);
+            this.ChildTestSteps.Add(mixerPowerTestStep);
+            this.ChildTestSteps.Add(mixerSetupTestStep);
             this.ChildTestSteps.Add(sweptIMDNewTrace);
 
             // Once we have all child steps, lets get the number of points


### PR DESCRIPTION
Send MixerApply after setting SetPortLO in MixerSetupTestStep.cs
Change sequence of child steps for all converter measurement channels
Close #84 