### PR TITLE
Added option to use title as column name for result publish

### DIFF
--- a/OpenTap.Plugins.PNAX/Acquisition/StoreSingleTrace.cs
+++ b/OpenTap.Plugins.PNAX/Acquisition/StoreSingleTrace.cs
@@ -27,12 +27,16 @@ namespace OpenTap.Plugins.PNAX
 
         [Display("MNum", Groups: new[] { "Trace" }, Order: 21)]
         public Input<int> mnum { get; set; }
+
+        [Display("Use Trace Title as Column Name", Groups: new[] { "Publish Results" }, Order: 30)]
+        public bool UseTraceTitle { get; set; }
         #endregion
 
         public StoreSingleTraceAdvanced()
         {
             Channel = new Input<int>();
             mnum = new Input<int>();
+            UseTraceTitle = false;
         }
 
         public override void Run()
@@ -55,6 +59,12 @@ namespace OpenTap.Plugins.PNAX
 
             List<List<string>> results = PNAX.StoreTraceData(Channel.Value, mnum.Value);
             PNAX.WaitForOperationComplete();
+            string MeasName = x.MeasName;
+
+            if (UseTraceTitle)
+            {
+                MeasName = PNAX.GetTraceTitle(Channel.Value, mnum.Value, MeasName);
+            }
 
             var xResult = results.Where((item, index) => index % 2 == 0).ToList();
             var yResult = results.Where((item, index) => index % 2 != 0).ToList();
@@ -70,7 +80,7 @@ namespace OpenTap.Plugins.PNAX
             if (xResult[0].Count == yResult[0].Count)
             {
                 // one data per frequency point
-                ResultColumn resultColumn2 = new ResultColumn($"{x.MeasName}", yResult[0].Select(double.Parse).Select(z => Math.Round(z, 2)).ToArray());
+                ResultColumn resultColumn2 = new ResultColumn($"{MeasName}", yResult[0].Select(double.Parse).Select(z => Math.Round(z, 2)).ToArray());
                 resultColumns.Add(resultColumn2);
             }
             else
@@ -86,9 +96,9 @@ namespace OpenTap.Plugins.PNAX
                     point2[index] = twoPoints[j++];
                 }
 
-                ResultColumn resultColumni = new ResultColumn($"{x.MeasName}_i", point1);
+                ResultColumn resultColumni = new ResultColumn($"{MeasName}_i", point1);
                 resultColumns.Add(resultColumni);
-                ResultColumn resultColumnj = new ResultColumn($"{x.MeasName}_j", point2);
+                ResultColumn resultColumnj = new ResultColumn($"{MeasName}_j", point2);
                 resultColumns.Add(resultColumnj);
 
             }

--- a/OpenTap.Plugins.PNAX/BaseSteps/AddNewTraceBaseStep.cs
+++ b/OpenTap.Plugins.PNAX/BaseSteps/AddNewTraceBaseStep.cs
@@ -11,7 +11,6 @@ namespace OpenTap.Plugins.PNAX
     public class AddNewTraceBaseStep : SingleTraceBaseStep
     {
         #region Settings
-
         [Browsable(false)]
         public bool EnableButton { get; set; } = true;
 
@@ -24,6 +23,12 @@ namespace OpenTap.Plugins.PNAX
             AddNewTrace();
         }
         #endregion
+
+        public override void UpdateTestStepName()
+        {
+            // No need to update Test Name on New Trace Test Step
+            // only on Single Trace
+        }
 
         public override void Run()
         {

--- a/OpenTap.Plugins.PNAX/BaseSteps/PNABaseStep.cs
+++ b/OpenTap.Plugins.PNAX/BaseSteps/PNABaseStep.cs
@@ -57,6 +57,10 @@ namespace OpenTap.Plugins.PNAX
                     {
                         (a as PNABaseStep).Channel = value;
                     }
+                    if (a is SingleTraceBaseStep)
+                    {
+                        (a as SingleTraceBaseStep).UpdateTestStepName();
+                    }
                 }
             }
         }

--- a/OpenTap.Plugins.PNAX/BaseSteps/SingleTraceBaseStep.cs
+++ b/OpenTap.Plugins.PNAX/BaseSteps/SingleTraceBaseStep.cs
@@ -117,7 +117,7 @@ namespace OpenTap.Plugins.PNAX
         }
 
 
-        protected virtual void UpdateTestStepName()
+        public virtual void UpdateTestStepName()
         {
             Trace = $"CH{Channel}_{measEnumName}";
             Name = $"CH{Channel}_{measEnumName}";

--- a/OpenTap.Plugins.PNAX/Converters/SweptIMD/SweptIMDNewTrace.cs
+++ b/OpenTap.Plugins.PNAX/Converters/SweptIMD/SweptIMDNewTrace.cs
@@ -69,7 +69,8 @@ namespace OpenTap.Plugins.PNAX
             set
             {
                 _IMDTraceType = value;
-                if (_IMDTraceType == IMDTraceTypeEnum.TonePower)
+                if ((_IMDTraceType == IMDTraceTypeEnum.TonePower) ||
+                    (_IMDTraceType == IMDTraceTypeEnum.ToneGain))
                 {
                     IMDOrderOptions = new List<int> { 1, 2, 3, 5, 7, 9 };
                     IMDOrder = 1;

--- a/OpenTap.Plugins.PNAX/General/Noise Figure Cold Source/GeneralNoiseFigureSingleTrace.cs
+++ b/OpenTap.Plugins.PNAX/General/Noise Figure Cold Source/GeneralNoiseFigureSingleTrace.cs
@@ -96,7 +96,7 @@ namespace OpenTap.Plugins.PNAX
             measClass = "Noise Figure Cold Source";
         }
 
-        protected override void UpdateTestStepName()
+        public override void UpdateTestStepName()
         {
             string m = Scpi.Format("{0}", Meas);
             this.Trace = $"CH{Channel}_{m}";

--- a/OpenTap.Plugins.PNAX/General/Swept IMD/GeneralSweptIMDNewTrace.cs
+++ b/OpenTap.Plugins.PNAX/General/Swept IMD/GeneralSweptIMDNewTrace.cs
@@ -36,7 +36,8 @@ namespace OpenTap.Plugins.PNAX
             set
             {
                 _IMDTraceType = value;
-                if (_IMDTraceType == IMDTraceTypeEnum.TonePower)
+                if ((_IMDTraceType == IMDTraceTypeEnum.TonePower) ||
+                    (_IMDTraceType == IMDTraceTypeEnum.ToneGain) )
                 {
                     IMDOrderOptions = new List<int> { 1, 2, 3, 5, 7, 9 };
                     IMDOrder = 1;

--- a/OpenTap.Plugins.PNAX/Instrument/PNALoadMeasStore.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNALoadMeasStore.cs
@@ -190,7 +190,7 @@ namespace OpenTap.Plugins.PNAX
                 foreach (var trace in traceNumList)
                 {
                     // trace is MNUM in help file
-                    ScpiCommand($"CALC{channel}:PAR:MNUM:SEL {trace}");
+                    SelectMeasurement(channel, trace);
                     var xString = ScpiQuery($"CALC{channel}:X:VAL?");
                     var xList = xString.Split(',').ToList();
                     int XCount = xList.Count;
@@ -258,7 +258,7 @@ namespace OpenTap.Plugins.PNAX
 
             // Return trace information
             // trace is MNUM in help file
-            ScpiCommand($"CALC{Channel}:PAR:MNUM:SEL {mnum}");
+            SelectMeasurement(Channel, mnum);
             var xString = ScpiQuery($"CALC{Channel}:X:VAL?");
             var xList = xString.Split(',').ToList();
 
@@ -324,7 +324,7 @@ namespace OpenTap.Plugins.PNAX
                 foreach (var trace in traceNumList)
                 {
                     // Select trace
-                    ScpiCommand($"CALC{channel}:PAR:MNUM:SEL {trace}");
+                    SelectMeasurement(channel, trace);
 
                     // Turn marker on
                     ScpiCommand($"CALC{channel}:MARK1:STAT 1");

--- a/OpenTap.Plugins.PNAX/Instrument/PNATraces.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNATraces.cs
@@ -89,9 +89,70 @@ namespace OpenTap.Plugins.PNAX
             }
         }
 
+        public bool GetTraceTitleState(int Window, int tnum)
+        {
+            return ScpiQuery<bool>($"DISPlay:WINDow{Window}:TRACe{tnum}:TITLe?");
+        }
+
+        public String GetTraceTitle(int Window, int tnum)
+        {
+            String titleData = ScpiQuery($"DISPlay:WINDow{Window}:TRACe{tnum}:TITLe:DATA?");
+            titleData = titleData.Replace("\"", "");
+            return titleData;
+        }
+
         public void SetTraceFormat(int Channel, int mnum, MeasurementFormatEnum meas)
         {
             ScpiCommand($"CALCulate{Channel}:MEASure{mnum}:FORMat {meas}");
+        }
+
+        public void SelectMeasurement(int Channel, int mnum)
+        {
+            ScpiCommand($"CALC{Channel}:PAR:MNUM:SEL {mnum}");
+        }
+
+        public void SelectMeasurement(int Channel, String mnum)
+        {
+            ScpiCommand($"CALC{Channel}:PAR:MNUM:SEL {mnum}");
+        }
+
+        public int GetSelectedTraceNumber(int Channel)
+        {
+            return ScpiQuery<int>($"CALC{Channel}:PAR:TNUMber?");
+        }
+
+        public int GetSelectedWindowNumber(int Channel)
+        {
+            return ScpiQuery<int>($"CALC{Channel}:PAR:WNUMber?");
+        }
+
+        public string GetTraceTitle(int Channel, int mnum, string MeasName)
+        {
+            // Set Active Measurement
+            SelectMeasurement(Channel, mnum);
+
+            // Get TNUM
+            int tnum = GetSelectedTraceNumber(Channel);
+
+            // Get WNUM
+            int wnum = GetSelectedWindowNumber(Channel);
+
+            // Get Trace Title using TNUM and WNUM
+            bool traceState = GetTraceTitleState(wnum, tnum);
+
+            if (traceState)
+            {
+                // Replace MeasName with TraceTitle
+                String traceTitle = GetTraceTitle(wnum, tnum);
+                MeasName = traceTitle;
+            }
+            else
+            {
+                // Title has not been set, 
+                // continue using MeasName
+            }
+
+            return MeasName;
         }
     }
 }

--- a/OpenTap.Plugins.PNAX/LMS/StoreMarkerData.cs
+++ b/OpenTap.Plugins.PNAX/LMS/StoreMarkerData.cs
@@ -65,7 +65,7 @@ namespace OpenTap.Plugins.PNAX
                     Log.Info($"Looking for Markers for Channel{channel} Trace: {trace}");
 
                     // trace is MNUM in help file
-                    PNAX.ScpiCommand($"CALC{channel}:PAR:MNUM:SEL {trace}");
+                    PNAX.SelectMeasurement(channel, trace);
 
                     for (int mkr = 1; mkr < 16; mkr++)
                     {

--- a/OpenTap.Plugins.PNAX/LMS/StoreSingleTrace.cs
+++ b/OpenTap.Plugins.PNAX/LMS/StoreSingleTrace.cs
@@ -29,6 +29,9 @@ namespace OpenTap.Plugins.PNAX
 
         [Display("File Name", Groups: new[] { "Trace" }, Order: 22)]
         public string filename { get; set; }
+
+        [Display("Use Trace Title as Column Name", Groups: new[] { "Publish Results" }, Order: 23)]
+        public bool UseTraceTitle { get; set; }
         #endregion
 
         public StoreSingleTrace()
@@ -36,6 +39,7 @@ namespace OpenTap.Plugins.PNAX
             Channel = 1;
             mnum = 1;
             filename = "MyTrace";
+            UseTraceTitle = false;
         }
 
         public override void Run()
@@ -50,6 +54,10 @@ namespace OpenTap.Plugins.PNAX
             List<List<string>> results = PNAX.StoreTraceData(Channel, mnum);
             PNAX.WaitForOperationComplete();
             string MeasName = PNAX.GetTraceName(Channel, mnum);
+            if (UseTraceTitle)
+            {
+                MeasName = PNAX.GetTraceTitle(Channel, mnum, MeasName);
+            }
 
             var xResult = results.Where((item, index) => index % 2 == 0).ToList();
             var yResult = results.Where((item, index) => index % 2 != 0).ToList();


### PR DESCRIPTION
Added option to use title as column for results publish for Store Single Trace, Store Single Trace Advanced and Store Data.
Fixed issue that prevented update test name for traces when the channel was changed 
added ability to select main tone for tone gain on Swept IMD and Converters SWept IMD

Close #95 