### PR TITLE
Fixing Preset on A Models

### DIFF
--- a/OpenTap.Plugins.PNAX/Instrument/PNA.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNA.cs
@@ -152,7 +152,10 @@ namespace OpenTap.Plugins.PNAX
         public void Preset()
         {
             ScpiCommand("SYST:FPR");
-            ScpiCommand("DISP:WIND OFF");
+            if (!IsModelA)
+            {
+                ScpiCommand("DISP:WIND OFF");
+            }
             WaitForOperationComplete();
             mnum = 1;
         }


### PR DESCRIPTION
Fixing Preset to not send DISP:WIND OFF when using A model instruments as the instrument will throw an error.