### PR TITLE
Store Marker can now be added to test plan and store trace data

### DIFF
--- a/OpenTap.Plugins.PNAX/LMS/StoreDispTraceData.cs
+++ b/OpenTap.Plugins.PNAX/LMS/StoreDispTraceData.cs
@@ -58,6 +58,9 @@ namespace OpenTap.Plugins.PNAX.LMS
 
             PNAX.SaveDispState(dir);
 
+            // Supported child steps will provide MetaData to be added to the publish table
+            RunChildSteps();
+
             UpgradeVerdict(Verdict.Pass);
         }
 

--- a/OpenTap.Plugins.PNAX/LMS/StoreMarkerData.cs
+++ b/OpenTap.Plugins.PNAX/LMS/StoreMarkerData.cs
@@ -11,10 +11,14 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using OpenTap.Plugins.PNAX.LMS;
 //using Newtonsoft.Json;
 
 namespace OpenTap.Plugins.PNAX
 {
+    [AllowAsChildIn(typeof(TestPlan))]
+    [AllowAsChildIn(typeof(StoreData))]
+    [AllowAsChildIn(typeof(StoreDispTraceData))]
     [AllowAsChildIn(typeof(StoreMultiPeakSearch))]
     [Display("Store Marker Data", Groups: new[] { "Network Analyzer", "Load/Measure/Store" }, Description: "Stores trace data from all channels.")]
     public class StoreMarkerData : StoreDataBase


### PR DESCRIPTION
Store Marker data can now be added to Test Plan, Store Trace data and Store Displayed trace data

Close #126 