### PR TITLE
add modulation distortion measurement class

### DIFF
--- a/OpenTap.Plugins.PNAX/BaseSteps/PNABaseStep.cs
+++ b/OpenTap.Plugins.PNAX/BaseSteps/PNABaseStep.cs
@@ -19,7 +19,7 @@ namespace OpenTap.Plugins.PNAX
         #region Settings
 
         [Browsable(false)]
-        public bool IsControlledByParent { get; set; } = true;
+        public bool IsControlledByParent { get; set; } = false;
         private PNAX _PNAX;
         [EnabledIf("IsControlledByParent", false, HideIfDisabled = false)]
         [Display("PNA", Order: 0.1)]

--- a/OpenTap.Plugins.PNAX/Calibration/SelectCalset.cs
+++ b/OpenTap.Plugins.PNAX/Calibration/SelectCalset.cs
@@ -1,0 +1,42 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX.Calibration
+{
+    [Display("Select Calset", Groups: new[] { "Network Analyzer", "Calibration" }, Description: "Selects and applies a Cal Set to the specified channel.")]
+    public class SelectCalset : TestStep
+    {
+        #region Settings
+        [Display("PNA", Order: 0.1)]
+        public PNAX PNAX { get; set; }
+
+        [Display("Channel", Order: 0.11)]
+        public int Channel { get; set; }
+
+        [Display("Cal Set Name", Order: 0.2)]
+        public String CalSetName { get; set; }
+        #endregion
+
+        public SelectCalset()
+        {
+            Channel = 1;
+            CalSetName = "MyCalSet";
+        }
+
+        public override void Run()
+        {
+            PNAX.LoadCalset(Channel, CalSetName, true);
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXChannel.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXChannel.cs
@@ -58,6 +58,7 @@ namespace OpenTap.Plugins.PNAX
             PNAX.SetSweepMode(Channel, SweepModeEnumType.SING);
 
             UpgradeVerdict(Verdict.Pass);
+            UpdateMetaData();
         }
     }
 }

--- a/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXChannel.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXChannel.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXChannel.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXChannel.cs
@@ -1,0 +1,63 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+    [Display("Modulation Distortion Converters Channel", Groups: new[] { "Network Analyzer", "Converters", "Modulation Distortion" }, Description: "Insert a description here")]
+    public class MODXChannel : PNABaseStep
+    {
+        #region Settings
+
+        [Display("Sweep Mode", Group: "Settings", Order: 10)]
+        public SweepModeEnumType sweepMode { get; set; }
+        #endregion
+
+        public MODXChannel()
+        {
+            IsControlledByParent = false;
+            Channel = 1;
+            sweepMode = SweepModeEnumType.SING;
+
+            // Traces
+            MODXNewTrace modNewTrace = new MODXNewTrace { IsControlledByParent = true, Channel = this.Channel };
+            MODModulate modModulate = new MODModulate { IsControlledByParent = true, Channel = this.Channel };
+            MODSourceCorrection modSourceCorrection = new MODSourceCorrection { IsControlledByParent = true, Channel = this.Channel };
+            MODSweep modSweep = new MODSweep { IsControlledByParent = true, Channel = this.Channel };
+            MODRFPath modRFPath = new MODRFPath { IsControlledByParent = true, Channel = this.Channel };
+            MODXMixer modxMixer = new MODXMixer { IsControlledByParent = true, Channel = this.Channel };
+            MODMeasure modMeasure = new MODMeasure { IsControlledByParent = true, Channel = this.Channel };
+
+            this.ChildTestSteps.Add(modNewTrace);
+            this.ChildTestSteps.Add(modSweep);
+            this.ChildTestSteps.Add(modRFPath);
+            this.ChildTestSteps.Add(modModulate);
+            this.ChildTestSteps.Add(modxMixer);
+            this.ChildTestSteps.Add(modSourceCorrection);
+            this.ChildTestSteps.Add(modMeasure);
+        }
+
+        public override void Run()
+        {
+            PNAX.GetNewTraceID(Channel);
+            // Define a dummy measurement so we can setup all channel parameters
+            // we will add the traces during the StandardSingleTrace or StandardNewTrace test steps
+            PNAX.ScpiCommand($"CALCulate{Channel}:CUST:DEFine \'CH{Channel}_DUMMY_1\',\'Modulation Distortion Converters\',\'PIn1\'");
+
+            RunChildSteps(); //If the step supports child steps.
+
+            PNAX.SetSweepMode(Channel, SweepModeEnumType.SING);
+
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXMixer.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXMixer.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXMixer.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXMixer.cs
@@ -182,6 +182,53 @@ namespace OpenTap.Plugins.PNAX
             LO2Attenuator = 0;
         }
 
+        [Browsable(false)]
+        public override List<(string, object)> GetMetaData()
+        {
+            List<(string, object)> retVal = new List<(string, object)>();
+            retVal.Add(("ConverterStages", ConverterStages));
+            retVal.Add(("InputMixerFrequency", InputMixerFrequency));
+            retVal.Add(("InputPort", InputPort));
+            retVal.Add(("OutputMixerFrequency", OutputMixerFrequency));
+            retVal.Add(("OutputPort", OutputPort));
+
+            retVal.Add(("LO1FractionalMultiplierNumerator", LO1FractionalMultiplierNumerator));
+            retVal.Add(("LO1FractionalMultiplierDenominator", LO1FractionalMultiplierDenominator));
+            retVal.Add(("LO1MixerFrequency", LO1MixerFrequency));
+            if (ConverterStages == ConverterStagesEnum._2)
+            {
+                retVal.Add(("IFMixerFrequency", IFMixerFrequency));
+                retVal.Add(("LO2FractionalMultiplierNumerator", LO2FractionalMultiplierNumerator));
+                retVal.Add(("LO2FractionalMultiplierDenominator", LO2FractionalMultiplierDenominator));
+                retVal.Add(("LO2MixerFrequency", LO2MixerFrequency));
+            }
+
+            retVal.Add(("EnableEmbeddedLO", EnableEmbeddedLO));
+            if (EnableEmbeddedLO)
+            {
+                retVal.Add(("TuningMethod", TuningMethod));
+                retVal.Add(("TuneEvery", TuneEvery));
+                retVal.Add(("BroadBandSearch", BroadBandSearch));
+                retVal.Add(("NoiseBW", NoiseBW));
+                retVal.Add(("MaxIterations", MaxIterations));
+                retVal.Add(("Tolerance", Tolerance));
+                retVal.Add(("LOFrequencyDelta", LOFrequencyDelta));
+            }
+            retVal.Add(("LO1Source", LO1Source));
+            retVal.Add(("LO1Power", LO1Power));
+            retVal.Add(("LO1SourceLevelingMode", LO1SourceLevelingMode));
+            retVal.Add(("LO1Attenuator", LO1Attenuator));
+
+            if (ConverterStages == ConverterStagesEnum._2)
+            {
+                retVal.Add(("LO2Source", LO2Source));
+                retVal.Add(("LO2Power", LO2Power));
+                retVal.Add(("LO2SourceLevelingMode", LO2SourceLevelingMode));
+                retVal.Add(("LO2Attenuator", LO2Attenuator));
+            }
+            return retVal;
+        }
+
         public override void Run()
         {
             RunChildSteps(); //If the step supports child steps.

--- a/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXMixer.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXMixer.cs
@@ -1,0 +1,248 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+    [AllowAsChildIn(typeof(TestPlan))]
+    [AllowAsChildIn(typeof(MODXChannel))]
+    [Display("Mixer", Groups: new[] { "Network Analyzer", "Converters", "Modulation Distortion" }, Description: "Insert a description here")]
+    public class MODXMixer : PNABaseStep
+    {
+        #region Settings
+
+        [Display("Input", Groups: new[] { "Mixer Setup", "Input" }, Order: 10)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.0")]
+        public double InputMixerFrequency { get; set; }
+
+        [Display("Port", Groups: new[] { "Mixer Setup", "Input" }, Order: 10.1)]
+        public MODDutPortEnum InputPort { get; set; }
+
+
+        [EnabledIf("DoubleStage", true, HideIfDisabled = true)]
+        [Display("IF", Groups: new[] { "Mixer Setup", "IF" }, Order: 11)]
+        public SidebandTypeEnum IFMixerFrequency { get; set; }
+
+        [Display("Output", Groups: new[] { "Mixer Setup", "Output" }, Order: 12)]
+        public SidebandTypeEnum OutputMixerFrequency { get; set; }
+
+        [Display("Port", Groups: new[] { "Mixer Setup", "Output" }, Order: 13)]
+        public MODDutPortEnum OutputPort { get; set; }
+
+
+
+        [Display("LO1 Fractional Multiplier Numerator", Groups: new[] { "Mixer Setup", "LO1" }, Order: 20)]
+        public int LO1FractionalMultiplierNumerator { get; set; }
+
+        [Display("LO1 Fractional Multiplier Denominator", Groups: new[] { "Mixer Setup", "LO1" }, Order: 21)]
+        public int LO1FractionalMultiplierDenominator { get; set; }
+
+        [Display("LO1", Groups: new[] { "Mixer Setup", "LO1" }, Order: 22)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.0")]
+        public double LO1MixerFrequency { get; set; }
+
+
+        [Display("LO2 Fractional Multiplier Numerator", Groups: new[] { "Mixer Setup", "LO2" }, Order: 30)]
+        [EnabledIf("DoubleStage", true, HideIfDisabled = true)]
+        public int LO2FractionalMultiplierNumerator { get; set; }
+
+        [Display("LO2 Fractional Multiplier Denominator", Groups: new[] { "Mixer Setup", "LO2" }, Order: 31)]
+        [EnabledIf("DoubleStage", true, HideIfDisabled = true)]
+        public int LO2FractionalMultiplierDenominator { get; set; }
+
+        [EnabledIf("DoubleStage", true, HideIfDisabled = true)]
+        [Display("LO2", Groups: new[] { "Mixer Setup", "LO2" }, Order: 32)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.0")]
+        public double LO2MixerFrequency { get; set; }
+
+
+
+
+        [Display("Enable Embedded LO", Groups: new[] { "Mixer Setup", "Embedded LO" }, Order: 40)]
+        public bool EnableEmbeddedLO { get; set; }
+
+        [EnabledIf("EnableEmbeddedLO", true, HideIfDisabled = true)]
+        [Display("Tuning Method", Groups: new[] { "Mixer Setup", "Embedded LO" }, Order: 41)]
+        public TuningMethodEnum TuningMethod { get; set; }
+
+        [EnabledIf("EnableEmbeddedLO", true, HideIfDisabled = true)]
+        [Display("Tune Every", Groups: new[] { "Mixer Setup", "Embedded LO" }, Order: 44)]
+        public int TuneEvery { get; set; }
+
+        [EnabledIf("EnableEmbeddedLO", true, HideIfDisabled = true)]
+        [Display("Broadband Search", Groups: new[] { "Mixer Setup", "Embedded LO" }, Order: 45)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000")]
+        public int BroadBandSearch { get; set; }
+
+        [EnabledIf("EnableEmbeddedLO", true, HideIfDisabled = true)]
+        [Display("Noise BW", Groups: new[] { "Mixer Setup", "Embedded LO" }, Order: 46)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000")]
+        public int NoiseBW { get; set; }
+
+        [EnabledIf("EnableEmbeddedLO", true, HideIfDisabled = true)]
+        [Display("Max Iterations", Groups: new[] { "Mixer Setup", "Embedded LO" }, Order: 47)]
+        public int MaxIterations { get; set; }
+
+        [EnabledIf("EnableEmbeddedLO", true, HideIfDisabled = true)]
+        [Display("Tolerance", Groups: new[] { "Mixer Setup", "Embedded LO" }, Order: 48)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000")]
+        public int Tolerance { get; set; }
+
+        [EnabledIf("EnableEmbeddedLO", true, HideIfDisabled = true)]
+        [Display("LO Frequency Delta", Groups: new[] { "Mixer Setup", "Embedded LO" }, Order: 49)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000")]
+        public double LOFrequencyDelta { get; set; }
+
+
+
+
+        [Display("LO1 Source", Groups: new[] { "Power", "LO1" }, Order: 50)]
+        public string LO1Source { get; set; }
+
+        [Display("LO1 Power", Groups: new[] { "Power", "LO1" }, Order: 51)]
+        [Unit("dBm", UseEngineeringPrefix: true, StringFormat: "0.00")]
+        public double LO1Power { get; set; }
+
+        [Display("LO1 Leveling", Groups: new[] { "Power", "LO1" }, Order: 52)]
+        public SourceLevelingModeType LO1SourceLevelingMode{ get; set; }
+
+        [Display("LO1 Attenuator", Groups: new[] { "Power", "LO1" }, Order: 53)]
+        [Unit("dB", UseEngineeringPrefix: true, StringFormat: "0")]
+        public double LO1Attenuator { get; set; }
+
+
+
+
+        [EnabledIf("DoubleStage", true, HideIfDisabled = true)]
+        [EnabledIf("ConverterStages", ConverterStagesEnum._2, HideIfDisabled = true)]
+        [Display("LO2 Source", Groups: new[] { "Power", "LO2" }, Order: 60)]
+        public string LO2Source { get; set; }
+
+        [EnabledIf("ConverterStages", ConverterStagesEnum._2, HideIfDisabled = true)]
+        [Display("LO2 Power", Groups: new[] { "Power", "LO2" }, Order: 61)]
+        [Unit("dBm", UseEngineeringPrefix: true, StringFormat: "0.00")]
+        public double LO2Power { get; set; }
+
+        [EnabledIf("ConverterStages", ConverterStagesEnum._2, HideIfDisabled = true)]
+        [Display("LO2 Leveling", Groups: new[] { "Power", "LO2" }, Order: 62)]
+        public SourceLevelingModeType LO2SourceLevelingMode { get; set; }
+
+        [EnabledIf("ConverterStages", ConverterStagesEnum._2, HideIfDisabled = true)]
+        [Display("LO2 Attenuator", Groups: new[] { "Power", "LO2" }, Order: 63)]
+        [Unit("dB", UseEngineeringPrefix: true, StringFormat: "0")]
+        public double LO2Attenuator { get; set; }
+
+        #endregion
+
+        public MODXMixer()
+        {
+            IsConverterEditable = true;
+            IsConverter = true;
+
+            ConverterStages = ConverterStagesEnum._1;
+            InputMixerFrequency = 1.5e9;
+            InputPort = MODDutPortEnum.Port1;
+            IFMixerFrequency = SidebandTypeEnum.Low;
+            OutputMixerFrequency = SidebandTypeEnum.Low;
+            OutputPort = MODDutPortEnum.Port2;
+
+            LO1FractionalMultiplierNumerator = 1;
+            LO1FractionalMultiplierDenominator = 1;
+            LO1MixerFrequency = 0;
+            LO2FractionalMultiplierNumerator = 1;
+            LO2FractionalMultiplierDenominator = 1;
+            LO2MixerFrequency = 0;
+
+            EnableEmbeddedLO = false;
+            TuningMethod = TuningMethodEnum.BroadbandAndPrecise;
+            TuneEvery = 1;
+            BroadBandSearch = 3000000;
+            NoiseBW = 3200;
+            MaxIterations = 5;
+            Tolerance = 1;
+            LOFrequencyDelta = 0;
+
+            LO1Source = "Not controlled";
+            LO1Power = -10;
+            LO1SourceLevelingMode = SourceLevelingModeType.OPENloop;
+            LO1Attenuator = 0;
+
+            LO2Source = "Not controlled";
+            LO2Power = -10;
+            LO2SourceLevelingMode = SourceLevelingModeType.OPENloop;
+            LO2Attenuator = 0;
+        }
+
+        public override void Run()
+        {
+            RunChildSteps(); //If the step supports child steps.
+
+            // Start from scratch
+            PNAX.MixerDiscard(Channel);
+
+            // Setup
+            PNAX.SetConverterStages(Channel, ConverterStages);
+            PNAX.MODCarrierFreq(Channel, InputMixerFrequency);
+            PNAX.SetFrequencyOutputSideband(Channel, OutputMixerFrequency);
+
+            PNAX.SetLOFractionalMultiplierNumerator(Channel, 1, LO1FractionalMultiplierNumerator);
+            PNAX.SetLOFractionalMultiplierDenominator(Channel, 1, LO1FractionalMultiplierDenominator);
+            PNAX.SetFrequencyLOFixed(Channel, 1, LO1MixerFrequency);
+            if (ConverterStages == ConverterStagesEnum._2)
+            {
+                PNAX.SetFrequencyIFSideband(Channel, IFMixerFrequency);
+
+                PNAX.SetLOFractionalMultiplierNumerator(Channel, 2, LO2FractionalMultiplierNumerator);
+                PNAX.SetLOFractionalMultiplierDenominator(Channel, 2, LO2FractionalMultiplierDenominator);
+                PNAX.SetFrequencyLOFixed(Channel, 2, LO2MixerFrequency);
+                PNAX.MixerCalc(Channel);
+            }
+            //PNAX.MixerApply(Channel);
+
+            // Embedded
+            PNAX.SetEnableEmbeddedLO(Channel, EnableEmbeddedLO);
+            if (EnableEmbeddedLO)
+            {
+                PNAX.SetTuningMethod(Channel, TuningMethod);
+                PNAX.SetTuningInterval(Channel, TuneEvery);
+                PNAX.SetTuningSpan(Channel, BroadBandSearch);
+                PNAX.SetTuningNoiseBW(Channel, NoiseBW);
+                PNAX.SetTuningMaxIterations(Channel, MaxIterations);
+                PNAX.SetTuningTolerance(Channel, Tolerance);
+                PNAX.SetLOFrequencyDelta(Channel, LOFrequencyDelta);
+            }
+            PNAX.MixerApply(Channel);
+
+
+            // Power
+            PNAX.SetPortLO(Channel, 1, LO1Source);
+            //PNAX.MODMixerSourceRole(Channel, "INPUT", "Device0");
+            PNAX.SetLOPower(Channel, 1, LO1Power);
+            PNAX.SetSourceLevelingMode(Channel, InputPort, LO1SourceLevelingMode.ToString());
+            PNAX.SetSourceAttenuator(Channel, InputPort, LO1Attenuator);
+
+            if (ConverterStages == ConverterStagesEnum._2)
+            {
+                PNAX.SetPortLO(Channel, 2, LO2Source);
+                //PNAX.MODMixerSourceRole(Channel, "INPUT", "Device0");
+                PNAX.SetLOPower(Channel, 2, LO2Power);
+                PNAX.SetSourceLevelingMode(Channel, InputPort, LO1SourceLevelingMode.ToString());
+                PNAX.SetSourceAttenuator(Channel, InputPort, LO1Attenuator);
+            }
+            // Apply changes to instrument
+            PNAX.MixerCalc(Channel);
+            PNAX.MixerApply(Channel);
+
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXNewTrace.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXNewTrace.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXNewTrace.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXNewTrace.cs
@@ -29,6 +29,14 @@ namespace OpenTap.Plugins.PNAX
             ChildTestSteps.Add(new MODXSingleTrace() { PNAX = this.PNAX, Meas = this.Meas, Channel = this.Channel, IsControlledByParent = true, EnableTraceSettings = true });
         }
 
+        [Browsable(false)]
+        public override List<(string, object)> GetMetaData()
+        {
+            List<(string, object)> retVal = new List<(string, object)>();
+
+            return retVal;
+        }
+
         protected override void DeleteDummyTrace()
         {
             PNAX.ScpiCommand($"CALCulate{Channel}:PARameter:DELete \'CH{Channel}_DUMMY_1\'");

--- a/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXNewTrace.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXNewTrace.cs
@@ -1,0 +1,42 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+    [AllowAsChildIn(typeof(MODXChannel))]
+    [AllowChildrenOfType(typeof(MODXSingleTrace))]
+    [Display("Modulation Distortion New Trace", Groups: new[] { "Network Analyzer", "Converters", "Modulation Distortion" }, Description: "Insert a description here")]
+    public class MODXNewTrace : AddNewTraceBaseStep
+    {
+        #region Settings
+        [Display("Meas", Groups: new[] { "Trace" }, Order: 11)]
+        public MODTraceEnum Meas { get; set; }
+        #endregion
+
+        public MODXNewTrace()
+        {
+            Meas = MODTraceEnum.PIn1;
+            ChildTestSteps.Add(new MODXSingleTrace() { PNAX = this.PNAX, Meas = this.Meas, Channel = this.Channel, IsControlledByParent = true, EnableTraceSettings = true });
+        }
+
+        protected override void DeleteDummyTrace()
+        {
+            PNAX.ScpiCommand($"CALCulate{Channel}:PARameter:DELete \'CH{Channel}_DUMMY_1\'");
+        }
+
+        protected override void AddNewTrace()
+        {
+            ChildTestSteps.Add(new MODXSingleTrace() { PNAX = this.PNAX, Meas = this.Meas, Channel = this.Channel, IsControlledByParent = true, EnableTraceSettings = true });
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXSingleTrace.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXSingleTrace.cs
@@ -1,0 +1,49 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+    [AllowAsChildIn(typeof(MODXNewTrace))]
+    [Display("Modulation Distortion Single Trace", Groups: new[] { "Network Analyzer", "Converters", "Modulation Distortion" }, Description: "Insert a description here")]
+    public class MODXSingleTrace : SingleTraceBaseStep
+    {
+        #region Settings
+        private MODTraceEnum _Meas;
+
+        [EnabledIf(nameof(CustomTraceMeas), false, HideIfDisabled = true)]
+        [Display("Meas", Groups: new[] { "Trace" }, Order: 11.1)]
+        public MODTraceEnum Meas
+        {
+            get
+            {
+                return _Meas;
+            }
+            set
+            {
+                _Meas = value;
+                string scpi = Scpi.Format("{0}", value);
+                measEnumName = scpi;    // value.ToString();
+                UpdateTestStepName();
+            }
+        }
+
+        #endregion
+
+        public MODXSingleTrace()
+        {
+            Meas = MODTraceEnum.PIn1;
+            measClass = "Modulation Distortion Converters";
+        }
+
+    }
+}

--- a/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXSingleTrace.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Modulation Distortion/MODXSingleTrace.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
@@ -17,13 +17,16 @@ namespace OpenTap.Plugins.PNAX
     public class MODChannel : PNABaseStep
     {
         #region Settings
-        // ToDo: Add property here for each parameter the end user should be able to change
+
+        [Display("Sweep Mode", Group: "Settings", Order: 10)]
+        public SweepModeEnumType sweepMode { get; set; }
         #endregion
 
         public MODChannel()
         {
             IsControlledByParent = false;
             Channel = 1;
+            sweepMode = SweepModeEnumType.SING;
 
             // Traces
             MODNewTrace modNewTrace = new MODNewTrace { IsControlledByParent = true, Channel = this.Channel };
@@ -47,6 +50,8 @@ namespace OpenTap.Plugins.PNAX
             PNAX.ScpiCommand($"CALCulate{Channel}:CUST:DEFine \'CH{Channel}_DUMMY_1\',\'Modulation Distortion\',\'PIn1\'");
 
             RunChildSteps(); //If the step supports child steps.
+
+            PNAX.SetSweepMode(Channel, SweepModeEnumType.SING);
 
             UpgradeVerdict(Verdict.Pass);
         }

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
@@ -56,6 +56,7 @@ namespace OpenTap.Plugins.PNAX
             PNAX.SetSweepMode(Channel, SweepModeEnumType.SING);
 
             UpgradeVerdict(Verdict.Pass);
+            UpdateMetaData();
         }
     }
 }

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
@@ -29,10 +29,12 @@ namespace OpenTap.Plugins.PNAX
             MODNewTrace modNewTrace = new MODNewTrace { IsControlledByParent = true, Channel = this.Channel };
             MODModulate modModulate = new MODModulate { IsControlledByParent = true, Channel = this.Channel };
             MODSweep modSweep = new MODSweep { IsControlledByParent = true, Channel = this.Channel };
+            MODRFPath modRFPath = new MODRFPath { IsControlledByParent = true, Channel = this.Channel };
             MODMeasure modMeasure = new MODMeasure { IsControlledByParent = true, Channel = this.Channel };
 
             this.ChildTestSteps.Add(modNewTrace);
             this.ChildTestSteps.Add(modSweep);
+            this.ChildTestSteps.Add(modRFPath);
             this.ChildTestSteps.Add(modModulate);
             this.ChildTestSteps.Add(modMeasure);
         }

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
@@ -1,0 +1,50 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+    [Display("Modulation Distortion Channel", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
+    public class MODChannel : PNABaseStep
+    {
+        #region Settings
+        // ToDo: Add property here for each parameter the end user should be able to change
+        #endregion
+
+        public MODChannel()
+        {
+            IsControlledByParent = false;
+            Channel = 1;
+
+            MODModulate modModulate = new MODModulate { IsControlledByParent = true, Channel = this.Channel };
+            MODMeasure modMeasure = new MODMeasure { IsControlledByParent = true, Channel = this.Channel };
+            // Traces
+            MODNewTrace modNewTrace = new MODNewTrace { IsControlledByParent = true, Channel = this.Channel };
+
+            this.ChildTestSteps.Add(modModulate);
+            this.ChildTestSteps.Add(modMeasure);
+            this.ChildTestSteps.Add(modNewTrace);
+        }
+
+        public override void Run()
+        {
+            PNAX.GetNewTraceID(Channel);
+            // Define a dummy measurement so we can setup all channel parameters
+            // we will add the traces during the StandardSingleTrace or StandardNewTrace test steps
+            PNAX.ScpiCommand($"CALCulate{Channel}:CUST:DEFine \'CH{Channel}_DUMMY_1\',\'Modulation Distortion\',\'PIn1\'");
+
+            RunChildSteps(); //If the step supports child steps.
+
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
@@ -25,10 +25,10 @@ namespace OpenTap.Plugins.PNAX
             IsControlledByParent = false;
             Channel = 1;
 
-            MODModulate modModulate = new MODModulate { IsControlledByParent = true, Channel = this.Channel };
-            MODMeasure modMeasure = new MODMeasure { IsControlledByParent = true, Channel = this.Channel };
             // Traces
             MODNewTrace modNewTrace = new MODNewTrace { IsControlledByParent = true, Channel = this.Channel };
+            MODModulate modModulate = new MODModulate { IsControlledByParent = true, Channel = this.Channel };
+            MODMeasure modMeasure = new MODMeasure { IsControlledByParent = true, Channel = this.Channel };
 
             this.ChildTestSteps.Add(modModulate);
             this.ChildTestSteps.Add(modMeasure);

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
@@ -31,6 +31,7 @@ namespace OpenTap.Plugins.PNAX
             // Traces
             MODNewTrace modNewTrace = new MODNewTrace { IsControlledByParent = true, Channel = this.Channel };
             MODModulate modModulate = new MODModulate { IsControlledByParent = true, Channel = this.Channel };
+            MODSourceCorrection modSourceCorrection = new MODSourceCorrection { IsControlledByParent = true, Channel = this.Channel };
             MODSweep modSweep = new MODSweep { IsControlledByParent = true, Channel = this.Channel };
             MODRFPath modRFPath = new MODRFPath { IsControlledByParent = true, Channel = this.Channel };
             MODMeasure modMeasure = new MODMeasure { IsControlledByParent = true, Channel = this.Channel };
@@ -39,6 +40,7 @@ namespace OpenTap.Plugins.PNAX
             this.ChildTestSteps.Add(modSweep);
             this.ChildTestSteps.Add(modRFPath);
             this.ChildTestSteps.Add(modModulate);
+            this.ChildTestSteps.Add(modSourceCorrection);
             this.ChildTestSteps.Add(modMeasure);
         }
 

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODChannel.cs
@@ -28,11 +28,13 @@ namespace OpenTap.Plugins.PNAX
             // Traces
             MODNewTrace modNewTrace = new MODNewTrace { IsControlledByParent = true, Channel = this.Channel };
             MODModulate modModulate = new MODModulate { IsControlledByParent = true, Channel = this.Channel };
+            MODSweep modSweep = new MODSweep { IsControlledByParent = true, Channel = this.Channel };
             MODMeasure modMeasure = new MODMeasure { IsControlledByParent = true, Channel = this.Channel };
 
+            this.ChildTestSteps.Add(modNewTrace);
+            this.ChildTestSteps.Add(modSweep);
             this.ChildTestSteps.Add(modModulate);
             this.ChildTestSteps.Add(modMeasure);
-            this.ChildTestSteps.Add(modNewTrace);
         }
 
         public override void Run()

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODDistortionTable.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODDistortionTable.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODDistortionTable.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODDistortionTable.cs
@@ -1,0 +1,67 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+    [Display("MOD Distortion Table", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
+    public class MODDistortionTable : PNABaseStep
+    {
+        #region Settings
+        [Display("Window", Group: "Settings", Order: 20)]
+        public int Window { get; set; }
+
+        [Display("Show Table", Group: "Settings", Order: 21)]
+        public bool ShowTable { get; set; }
+
+        [Display("Carrier", Group: "Settings", Order: 22)]
+        public MODTableSetupCarrierEnum MODTableSetupCarrier { get; set; }
+
+        [Display("EVM", Group: "Settings", Order: 23)]
+        public MODTableSetupEVMEnum MODTableSetupEVM { get; set; }
+
+        [Display("NPR", Group: "Settings", Order: 24)]
+        public MODTableSetupNPREnum MODTableSetupNPR { get; set; }
+
+        [Display("ACP", Group: "Settings", Order: 25)]
+        public MODTableSetupACPEnum MODTableSetupACP { get; set; }
+
+        [Display("ACP Avg", Group: "Settings", Order: 26)]
+        public MODTableSetupACPAvgEnum MODTableSetupAvg { get; set; }
+        #endregion
+
+        public MODDistortionTable()
+        {
+            Window = 1;
+            ShowTable = true;
+            MODTableSetupCarrier = MODTableSetupCarrierEnum.CarrierIn1dBm | MODTableSetupCarrierEnum.CarrierOut2dBm | MODTableSetupCarrierEnum.CarrierGain21dB | MODTableSetupCarrierEnum.CarrierIBW;
+            MODTableSetupEVM = MODTableSetupEVMEnum.EVMDistEq21;
+            MODTableSetupNPR = MODTableSetupNPREnum.NPROut2dBc;
+            MODTableSetupACP = MODTableSetupACPEnum.ACPUpIn1dBc | MODTableSetupACPEnum.ACPUpOut2dBc;
+            MODTableSetupAvg = 0;
+        }
+
+        public override void Run()
+        {
+            RunChildSteps(); //If the step supports child steps.
+
+            PNAX.MODShowTable(Channel, ShowTable);
+            PNAX.MODTableAddParameter(Channel, MODTableSetupCarrier);
+            PNAX.MODTableAddParameter(Channel, MODTableSetupEVM);
+            PNAX.MODTableAddParameter(Channel, MODTableSetupNPR);
+            PNAX.MODTableAddParameter(Channel, MODTableSetupACP);
+            PNAX.MODTableAddParameter(Channel, MODTableSetupAvg);
+
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODGetData.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODGetData.cs
@@ -1,0 +1,66 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+    [Display("MOD Get Data", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
+    public class MODGetData : PNABaseStep
+    {
+        #region Settings
+        [Display("All data", Group: "Settings", Order: 21)]
+        public bool AllData { get; set; }
+
+        [EnabledIf("AllData", false, HideIfDisabled = true)]
+        [Display("Parameter Name", Group: "Settings", Order: 22)]
+        public string paramName { get; set; }
+        #endregion
+
+        public MODGetData()
+        {
+            AllData = true;
+            paramName = "Carrier In1 dBm";
+        }
+
+        public override void Run()
+        {
+            RunChildSteps(); //If the step supports child steps.
+
+            List<string> ResultNames = new List<string>();
+            List<IConvertible> ResultValues = new List<IConvertible>();
+
+            if (AllData)
+            {
+                List<string> allColumns = PNAX.MODGetAllColumnNames(Channel);
+                foreach(string paramName in allColumns)
+                {
+                    double value = PNAX.MODGetDataValue(Channel, paramName);
+
+                    ResultNames.Add(paramName);
+                    ResultValues.Add((IConvertible)value);
+                }
+            }
+            else
+            {
+                // Query a particular field
+                double value = PNAX.MODGetDataValue(Channel, paramName);
+
+                ResultNames.Add(paramName);
+                ResultValues.Add((IConvertible)value);
+            }
+
+            Results.Publish($"MOD_Data_Channel_{Channel.ToString()}", ResultNames, ResultValues.ToArray());
+
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODGetData.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODGetData.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODMeasure.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODMeasure.cs
@@ -15,6 +15,7 @@ namespace OpenTap.Plugins.PNAX
 {
     [AllowAsChildIn(typeof(TestPlan))]
     [AllowAsChildIn(typeof(MODChannel))]
+    [AllowAsChildIn(typeof(MODXChannel))]
     [Display("MOD Measure", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
     public class MODMeasure : PNABaseStep
     {

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODMeasure.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODMeasure.cs
@@ -153,6 +153,49 @@ namespace OpenTap.Plugins.PNAX
             DutNF = 0;
         }
 
+        [Browsable(false)]
+        public override List<(string, object)> GetMetaData()
+        {
+            List<(string, object)> retVal = new List<(string, object)>();
+            retVal.Add(("MODMeasurementType", MODMeasurementType));
+            if (Autofill)
+            {
+                retVal.Add(("Autofill", Autofill));
+            }
+            else
+            {
+                retVal.Add(("MODCarrierOffset", MODCarrierOffset));
+                retVal.Add(("MODCarrierIBW", MODCarrierIBW));
+                if ((MODMeasurementType == MODMeasurementTypeEnum.ACP) ||
+                    (MODMeasurementType == MODMeasurementTypeEnum.ACPEVM))
+                {
+                    retVal.Add(("MODACPLowOffset", MODACPLowOffset));
+                    retVal.Add(("MODACPLowIBW", MODACPLowIBW));
+                    retVal.Add(("MODACPUpperOffset", MODACPUpperOffset));
+                    retVal.Add(("MODACPUpperIBW", MODACPUpperIBW));
+                }
+                else if ((MODMeasurementType == MODMeasurementTypeEnum.NPR))
+                {
+                    retVal.Add(("MODNPROffset", MODNPROffset));
+                    retVal.Add(("MODNPRIBW", MODNPRIBW));
+                }
+                if (EnableMeasurementDetails)
+                {
+                    retVal.Add(("EnableMeasurementDetails", EnableMeasurementDetails));
+                    retVal.Add(("EqualizationAperture", EqualizationAperture));
+                    retVal.Add(("EqualizationApertureAuto", EqualizationApertureAuto));
+                    retVal.Add(("MODAntialiasFilter", MODAntialiasFilter));
+                    retVal.Add(("EVMNormalization", EVMNormalization));
+                    retVal.Add(("MODFilter", MODFilter));
+                    retVal.Add(("MODAlpha", MODAlpha));
+                    retVal.Add(("SymbolRate", SymbolRate));
+                    retVal.Add(("SymbolRateAuto", SymbolRateAuto));
+                    retVal.Add(("DutNF", DutNF));
+                }
+            }
+            return retVal;
+        }
+
         public override void Run()
         {
             RunChildSteps(); //If the step supports child steps.

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODMeasure.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODMeasure.cs
@@ -74,7 +74,7 @@ namespace OpenTap.Plugins.PNAX
 
 
         [EnabledIf("EnableMeasurementDetails", true, HideIfDisabled = true)]
-        [Display("Equalization Aperture", Group: "Measurement Details", Order: 31)]
+        [Display("Equalization Aperture Auto", Group: "Measurement Details", Order: 31)]
         public bool EqualizationApertureAuto { get; set; }
 
         [EnabledIf("EnableMeasurementDetails", true, HideIfDisabled = true)]

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODMeasure.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODMeasure.cs
@@ -1,0 +1,122 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+    [AllowAsChildIn(typeof(TestPlan))]
+    [AllowAsChildIn(typeof(MODChannel))]
+    [Display("MOD Measure", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
+    public class MODMeasure : PNABaseStep
+    {
+        #region Settings
+        [Display("Measurement Type", Group: "Settings", Order: 21)]
+        public MODMeasurementTypeEnum MODMeasurementType { get; set; }
+
+        [Display("Autofill", Group: "Settings", Order: 21.1)]
+        public bool Autofill { get; set; }
+
+        [EnabledIf("Autofill", false, HideIfDisabled = true)]
+        [Display("Carrier Offset Freq", Group: "Settings", Order: 22)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0")]
+        public double MODCarrierOffset { get; set; }
+        [EnabledIf("Autofill", false, HideIfDisabled = true)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        [Display("Carrier Integration BW", Group: "Settings", Order: 23)]
+        public double MODCarrierIBW { get; set; }
+
+        [EnabledIf("Autofill", false, HideIfDisabled = true)]
+        [EnabledIf("MODMeasurementType", MODMeasurementTypeEnum.ACP, MODMeasurementTypeEnum.ACPEVM, HideIfDisabled = true)]
+        [Display("ACP Lower Offset Freq", Group: "Settings", Order: 24)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double MODACPLowOffset { get; set; }
+        [EnabledIf("Autofill", false, HideIfDisabled = true)]
+        [EnabledIf("MODMeasurementType", MODMeasurementTypeEnum.ACP, MODMeasurementTypeEnum.ACPEVM, HideIfDisabled = true)]
+        [Display("ACP Lower Integration BW", Group: "Settings", Order: 25)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double MODACPLowIBW { get; set; }
+
+        [EnabledIf("Autofill", false, HideIfDisabled = true)]
+        [EnabledIf("MODMeasurementType", MODMeasurementTypeEnum.ACP, MODMeasurementTypeEnum.ACPEVM, HideIfDisabled = true)]
+        [Display("ACP Upper Offset Freq", Group: "Settings", Order: 26)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double MODACPUpperOffset { get; set; }
+        [EnabledIf("Autofill", false, HideIfDisabled = true)]
+        [EnabledIf("MODMeasurementType", MODMeasurementTypeEnum.ACP, MODMeasurementTypeEnum.ACPEVM, HideIfDisabled = true)]
+        [Display("ACP Upper Integration BW", Group: "Settings", Order: 27)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double MODACPUpperIBW { get; set; }
+
+        [EnabledIf("Autofill", false, HideIfDisabled = true)]
+        [EnabledIf("MODMeasurementType", MODMeasurementTypeEnum.NPR, HideIfDisabled = true)]
+        [Display("Notch Offset Freq", Group: "Settings", Order: 26)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0")]
+        public double MODNPROffset { get; set; }
+        [EnabledIf("Autofill", false, HideIfDisabled = true)]
+        [EnabledIf("MODMeasurementType", MODMeasurementTypeEnum.NPR, HideIfDisabled = true)]
+        [Display("Notch Integration BW", Group: "Settings", Order: 27)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double MODNPRIBW { get; set; }
+
+        #endregion
+
+        public MODMeasure()
+        {
+            MODMeasurementType = MODMeasurementTypeEnum.BPWR;
+            Autofill = false;
+
+            MODCarrierOffset = 0;
+            MODCarrierIBW = 100e6;
+
+            MODACPLowOffset = -100e6;
+            MODACPLowIBW = 100e6;
+            MODACPUpperOffset = 100e6;
+            MODACPUpperIBW = 100e6;
+
+            MODNPROffset = 0;
+            MODNPRIBW = 10e6;
+        }
+
+        public override void Run()
+        {
+            RunChildSteps(); //If the step supports child steps.
+
+            PNAX.MODSetMeasType(Channel, MODMeasurementType);
+
+            if (Autofill)
+            {
+                PNAX.MODAutofill(Channel);
+            }
+            else
+            {
+                PNAX.MODSetOffset(Channel, MODCarrierOffset, MODMeasConfigTypeEnum.CARRier);
+                PNAX.MODSetIBW(Channel, MODCarrierIBW, MODMeasConfigTypeEnum.CARRier);
+
+                if ((MODMeasurementType == MODMeasurementTypeEnum.ACP) ||
+                    (MODMeasurementType == MODMeasurementTypeEnum.ACPEVM))
+                {
+                    PNAX.MODSetOffset(Channel, MODACPLowOffset, MODMeasConfigTypeEnum.ACPLower);
+                    PNAX.MODSetIBW(Channel, MODACPLowIBW, MODMeasConfigTypeEnum.ACPLower);
+
+                    PNAX.MODSetOffset(Channel, MODACPUpperOffset, MODMeasConfigTypeEnum.ACPUpper);
+                    PNAX.MODSetIBW(Channel, MODACPUpperIBW, MODMeasConfigTypeEnum.ACPUpper);
+                }
+                else if ((MODMeasurementType == MODMeasurementTypeEnum.NPR))
+                {
+                    PNAX.MODSetOffset(Channel, MODNPROffset, MODMeasConfigTypeEnum.Notch);
+                    PNAX.MODSetIBW(Channel, MODNPRIBW, MODMeasConfigTypeEnum.Notch);
+                }
+            }
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODMeasure.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODMeasure.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODModulate.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODModulate.cs
@@ -33,125 +33,125 @@ namespace OpenTap.Plugins.PNAX
         [Display("Source Correction", Group: "Settings", Order: 13)]
         public MODSourceCorrectionEnum ModSourceCorrection { get; set; }
 
-        [Display("Enable Cal", Group: "Modulation Cal \\ Power", Order: 21)]
+        [Display("Enable Cal", Groups: new[] { "Modulation Cal", "Power" }, Order: 21)]
         public bool PowerEnableCal { get; set; }
 
         [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Port", Group: "Modulation Cal \\ Power", Order: 22)]
+        [Display("Cal Port", Groups: new[] { "Modulation Cal", "Power" }, Order: 22)]
         public MODCalPortEnum PowerCalPort { get; set; }
 
         [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Span", Group: "Modulation Cal \\ Power", Order: 23)]
+        [Display("Cal Span", Groups: new[] { "Modulation Cal", "Power" }, Order: 23)]
         [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
         public double PowerCalSpan { get; set; }
 
         [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Max Iterations", Group: "Modulation Cal \\ Power", Order: 24)]
+        [Display("Max Iterations", Groups: new[] { "Modulation Cal", "Power" }, Order: 24)]
         public int PowerMaxIterations { get; set; }
 
         [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Desired Tolerance", Group: "Modulation Cal \\ Power", Order: 25)]
+        [Display("Desired Tolerance", Groups: new[] { "Modulation Cal", "Power" }, Order: 25)]
         [Unit("dB", UseEngineeringPrefix: false, StringFormat: "0.00")]
         public double PowerDesiredTolerance { get; set; }
 
 
-        [Display("Enable Cal", Group: "Modulation Cal \\ Equalization", Order: 31)]
+        [Display("Enable Cal", Groups: new[] { "Modulation Cal", "Equalization" }, Order: 31)]
         public bool EqualizationEnableCal { get; set; }
 
         [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Port", Group: "Modulation Cal \\ Equalization", Order: 32)]
+        [Display("Cal Port", Groups: new[] { "Modulation Cal", "Equalization" }, Order: 32)]
         public MODCalPortEnum EqualizationCalPort { get; set; }
 
         [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Span", Group: "Modulation Cal \\ Equalization", Order: 33)]
+        [Display("Cal Span", Groups: new[] { "Modulation Cal", "Equalization" }, Order: 33)]
         [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
         public double EqualizationCalSpan { get; set; }
 
         [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
-        [Display("Max Iterations", Group: "Modulation Cal \\ Equalization", Order: 34)]
+        [Display("Max Iterations", Groups: new[] { "Modulation Cal", "Equalization" }, Order: 34)]
         public int EqualizationMaxIterations { get; set; }
 
         [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
-        [Display("Desired Tolerance", Group: "Modulation Cal \\ Equalization", Order: 35)]
+        [Display("Desired Tolerance", Groups: new[] { "Modulation Cal", "Equalization" }, Order: 35)]
         [Unit("dB-pk", UseEngineeringPrefix: false, StringFormat: "0.00")]
         public double EqualizationDesiredTolerance { get; set; }
 
 
 
-        [Display("Enable Cal", Group: "Modulation Cal \\ Distortion", Order: 41)]
+        [Display("Enable Cal", Groups: new[] { "Modulation Cal", "Distortion" }, Order: 41)]
         public bool DistortionEnableCal { get; set; }
 
         [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Port", Group: "Modulation Cal \\ Distortion", Order: 42)]
+        [Display("Cal Port", Groups: new[] { "Modulation Cal", "Distortion" }, Order: 42)]
         public MODCalPortEnum DistortionCalPort { get; set; }
 
         [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Span", Group: "Modulation Cal \\ Distortion", Order: 43)]
+        [Display("Cal Span", Groups: new[] { "Modulation Cal", "Distortion" }, Order: 43)]
         [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
         public double DistortionCalSpan { get; set; }
 
         [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
-        [Display("Max Iterations", Group: "Modulation Cal \\ Distortion", Order: 44)]
+        [Display("Max Iterations", Groups: new[] { "Modulation Cal", "Distortion" }, Order: 44)]
         public int DistortionMaxIterations { get; set; }
 
         [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
-        [Display("Desired Tolerance", Group: "Modulation Cal \\ Distortion", Order: 45)]
+        [Display("Desired Tolerance", Groups: new[] { "Modulation Cal", "Distortion" }, Order: 45)]
         [Unit("dBc", UseEngineeringPrefix: false, StringFormat: "0.00")]
         public double DistortionDesiredTolerance { get; set; }
 
 
 
-        [Display("Enable Cal", Group: "Modulation Cal \\ ACP Lower", Order: 51)]
+        [Display("Enable Cal", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 51)]
         public bool ACPLowerEnableCal { get; set; }
 
         [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Port", Group: "Modulation Cal \\ ACP Lower", Order: 52)]
+        [Display("Cal Port", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 52)]
         public MODCalPortEnum ACPLowerCalPort { get; set; }
 
         [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Span", Group: "Modulation Cal \\ ACP Lower", Order: 53)]
+        [Display("Cal Span", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 53)]
         [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
         public double ACPLowerCalSpan { get; set; }
 
         [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Guard Band", Group: "Modulation Cal \\ ACP Lower", Order: 53.5)]
+        [Display("Guard Band", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 53.5)]
         [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
         public double ACPLowerGuardBand { get; set; }
 
         [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Max Iterations", Group: "Modulation Cal \\ ACP Lower", Order: 54)]
+        [Display("Max Iterations", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 54)]
         public int ACPLowerMaxIterations { get; set; }
 
         [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Desired Tolerance", Group: "Modulation Cal \\ ACP Lower", Order: 55)]
+        [Display("Desired Tolerance", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 55)]
         [Unit("dBc", UseEngineeringPrefix: false, StringFormat: "0.00")]
         public double ACPLowerDesiredTolerance { get; set; }
 
 
 
-        [Display("Enable Cal", Group: "Modulation Cal \\ ACP Upper", Order: 61)]
+        [Display("Enable Cal", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 61)]
         public bool ACPUpperEnableCal { get; set; }
 
         [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Port", Group: "Modulation Cal \\ ACP Upper", Order: 62)]
+        [Display("Cal Port", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 62)]
         public MODCalPortEnum ACPUpperCalPort { get; set; }
 
         [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Span", Group: "Modulation Cal \\ ACP Upper", Order: 63)]
+        [Display("Cal Span", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 63)]
         [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
         public double ACPUpperCalSpan { get; set; }
 
         [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
-        [Display("Guard Band", Group: "Modulation Cal \\ ACP Upper", Order: 53.5)]
+        [Display("Guard Band", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 53.5)]
         [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
         public double ACPUpperGuardBand { get; set; }
 
         [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
-        [Display("Max Iterations", Group: "Modulation Cal \\ ACP Upper", Order: 64)]
+        [Display("Max Iterations", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 64)]
         public int ACPUpperMaxIterations { get; set; }
 
         [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
-        [Display("Desired Tolerance", Group: "Modulation Cal \\ ACP Upper", Order: 65)]
+        [Display("Desired Tolerance", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 65)]
         [Unit("dBc", UseEngineeringPrefix: false, StringFormat: "0.00")]
         public double ACPUpperDesiredTolerance { get; set; }
         #endregion
@@ -264,7 +264,9 @@ namespace OpenTap.Plugins.PNAX
             // Execute Calibration
             PNAX.MODCalibrationMeasure(Channel, Source);
             //PNAX.WaitForOperationComplete(60000);
-            Log.Info("MOD Calibration Details: " + PNAX.MODGetCalibrationDetails(Channel, Source));
+            // Calibration details returns multiple single responses, using SCPIQuery leaves multiple lines on the queue
+            // Better not to use Calibration Details for now
+            //Log.Info("MOD Calibration Details: " + PNAX.MODGetCalibrationDetails(Channel, Source)); 
             Log.Info("MOD Calibration Status: " + PNAX.MODGetCalibrationStatus(Channel, Source));
 
             // Source Correction

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODModulate.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODModulate.cs
@@ -41,6 +41,17 @@ namespace OpenTap.Plugins.PNAX
             EnableModulation = false;
         }
 
+        [Browsable(false)]
+        public override List<(string, object)> GetMetaData()
+        {
+            List<(string, object)> retVal = new List<(string, object)>();
+            retVal.Add(("MODSource", MODSource));
+            retVal.Add(("ModulationFile", ModulationFile));
+            retVal.Add(("EnableModulation", EnableModulation));
+
+            return retVal;
+        }
+
         public override void Run()
         {
             RunChildSteps(); //If the step supports child steps.

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODModulate.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODModulate.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODModulate.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODModulate.cs
@@ -16,13 +16,13 @@ namespace OpenTap.Plugins.PNAX
     
     [AllowAsChildIn(typeof(TestPlan))]
     [AllowAsChildIn(typeof(MODChannel))]
-    [Display("Modulation", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
+    [Display("MOD Modulation", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
     public class MODModulate : PNABaseStep
     {
         #region Settings
 
         [Display("Source", Group: "Settings", Order: 10)]
-        public String Source { get; set; }
+        public String MODSource { get; set; }
 
         [Display("Modulation File", Group: "Settings", Order: 11)]
         public String ModulationFile { get; set; }
@@ -30,247 +30,24 @@ namespace OpenTap.Plugins.PNAX
         [Display("Enable Modulation", Group: "Settings", Order: 12)]
         public bool EnableModulation { get; set; }
 
-        [Display("Source Correction", Group: "Settings", Order: 13)]
-        public MODSourceCorrectionEnum ModSourceCorrection { get; set; }
 
-        [Display("Enable Cal", Groups: new[] { "Modulation Cal", "Power" }, Order: 21)]
-        public bool PowerEnableCal { get; set; }
-
-        [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Port", Groups: new[] { "Modulation Cal", "Power" }, Order: 22)]
-        public MODCalPortEnum PowerCalPort { get; set; }
-
-        [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Span", Groups: new[] { "Modulation Cal", "Power" }, Order: 23)]
-        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
-        public double PowerCalSpan { get; set; }
-
-        [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Max Iterations", Groups: new[] { "Modulation Cal", "Power" }, Order: 24)]
-        public int PowerMaxIterations { get; set; }
-
-        [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Desired Tolerance", Groups: new[] { "Modulation Cal", "Power" }, Order: 25)]
-        [Unit("dB", UseEngineeringPrefix: false, StringFormat: "0.00")]
-        public double PowerDesiredTolerance { get; set; }
-
-
-        [Display("Enable Cal", Groups: new[] { "Modulation Cal", "Equalization" }, Order: 31)]
-        public bool EqualizationEnableCal { get; set; }
-
-        [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Port", Groups: new[] { "Modulation Cal", "Equalization" }, Order: 32)]
-        public MODCalPortEnum EqualizationCalPort { get; set; }
-
-        [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Span", Groups: new[] { "Modulation Cal", "Equalization" }, Order: 33)]
-        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
-        public double EqualizationCalSpan { get; set; }
-
-        [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
-        [Display("Max Iterations", Groups: new[] { "Modulation Cal", "Equalization" }, Order: 34)]
-        public int EqualizationMaxIterations { get; set; }
-
-        [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
-        [Display("Desired Tolerance", Groups: new[] { "Modulation Cal", "Equalization" }, Order: 35)]
-        [Unit("dB-pk", UseEngineeringPrefix: false, StringFormat: "0.00")]
-        public double EqualizationDesiredTolerance { get; set; }
-
-
-
-        [Display("Enable Cal", Groups: new[] { "Modulation Cal", "Distortion" }, Order: 41)]
-        public bool DistortionEnableCal { get; set; }
-
-        [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Port", Groups: new[] { "Modulation Cal", "Distortion" }, Order: 42)]
-        public MODCalPortEnum DistortionCalPort { get; set; }
-
-        [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Span", Groups: new[] { "Modulation Cal", "Distortion" }, Order: 43)]
-        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
-        public double DistortionCalSpan { get; set; }
-
-        [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
-        [Display("Max Iterations", Groups: new[] { "Modulation Cal", "Distortion" }, Order: 44)]
-        public int DistortionMaxIterations { get; set; }
-
-        [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
-        [Display("Desired Tolerance", Groups: new[] { "Modulation Cal", "Distortion" }, Order: 45)]
-        [Unit("dBc", UseEngineeringPrefix: false, StringFormat: "0.00")]
-        public double DistortionDesiredTolerance { get; set; }
-
-
-
-        [Display("Enable Cal", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 51)]
-        public bool ACPLowerEnableCal { get; set; }
-
-        [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Port", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 52)]
-        public MODCalPortEnum ACPLowerCalPort { get; set; }
-
-        [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Span", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 53)]
-        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
-        public double ACPLowerCalSpan { get; set; }
-
-        [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Guard Band", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 53.5)]
-        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
-        public double ACPLowerGuardBand { get; set; }
-
-        [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Max Iterations", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 54)]
-        public int ACPLowerMaxIterations { get; set; }
-
-        [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
-        [Display("Desired Tolerance", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 55)]
-        [Unit("dBc", UseEngineeringPrefix: false, StringFormat: "0.00")]
-        public double ACPLowerDesiredTolerance { get; set; }
-
-
-
-        [Display("Enable Cal", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 61)]
-        public bool ACPUpperEnableCal { get; set; }
-
-        [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Port", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 62)]
-        public MODCalPortEnum ACPUpperCalPort { get; set; }
-
-        [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
-        [Display("Cal Span", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 63)]
-        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
-        public double ACPUpperCalSpan { get; set; }
-
-        [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
-        [Display("Guard Band", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 53.5)]
-        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
-        public double ACPUpperGuardBand { get; set; }
-
-        [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
-        [Display("Max Iterations", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 64)]
-        public int ACPUpperMaxIterations { get; set; }
-
-        [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
-        [Display("Desired Tolerance", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 65)]
-        [Unit("dBc", UseEngineeringPrefix: false, StringFormat: "0.00")]
-        public double ACPUpperDesiredTolerance { get; set; }
         #endregion
 
         public MODModulate()
         {
-            Source = "Port 1";
+            MODSource = "Port 1";
             ModulationFile = @"D:\data\d.mdx";
             EnableModulation = false;
-            ModSourceCorrection = MODSourceCorrectionEnum.OFF;
-
-            PowerEnableCal = true;
-            PowerCalPort = MODCalPortEnum.DUTIn1;
-            PowerCalSpan = 135.166667e6;
-            PowerMaxIterations = 3;
-            PowerDesiredTolerance = 0.1;
-
-            EqualizationEnableCal = true;
-            EqualizationCalPort = MODCalPortEnum.DUTIn1;
-            EqualizationCalSpan = 135.166667e6;
-            EqualizationMaxIterations = 3;
-            EqualizationDesiredTolerance = 0.3;
-
-            DistortionEnableCal = false;
-            DistortionCalPort = MODCalPortEnum.DUTIn1;
-            DistortionCalSpan = 135.166667e6;
-            DistortionMaxIterations = 3;
-            DistortionDesiredTolerance = -40;
-
-            ACPLowerEnableCal = false;
-            ACPLowerCalPort = MODCalPortEnum.DUTIn1;
-            ACPLowerCalSpan = 16.916667e6;
-            ACPLowerGuardBand = 0;
-            ACPLowerMaxIterations = 2;
-            ACPLowerDesiredTolerance = -40;
-
-            ACPUpperEnableCal = false;
-            ACPUpperCalPort = MODCalPortEnum.DUTIn1;
-            ACPUpperCalSpan = 16.916667e6;
-            ACPUpperGuardBand = 0;
-            ACPUpperMaxIterations = 2;
-            ACPUpperDesiredTolerance = -40;
-
-
-
         }
 
         public override void Run()
         {
             RunChildSteps(); //If the step supports child steps.
 
-            PNAX.SetMODSource(Channel, Source);
-            PNAX.MODLoadFile(Channel, Source, ModulationFile);
-            PNAX.MODEnableModulation(Channel, Source, EnableModulation);
+            PNAX.SetMODSource(Channel, MODSource);
+            PNAX.MODLoadFile(Channel, MODSource, ModulationFile);
+            PNAX.MODEnableModulation(Channel, MODSource, EnableModulation);
             PNAX.WaitForOperationComplete();
-
-
-            PNAX.WaitForOperationComplete();
-
-            PNAX.MODCalEnable(Channel, Source, PowerEnableCal, MODCalTypeEnum.POWer);
-            if (PowerEnableCal)
-            {
-                PNAX.MODCalPort(Channel, Source, PowerCalPort, MODCalTypeEnum.POWer);
-                PNAX.MODCalSpan(Channel, Source, PowerCalSpan, MODCalTypeEnum.POWer);
-                PNAX.MODCalMaxIterations(Channel, Source, PowerMaxIterations, MODCalTypeEnum.POWer);
-                PNAX.MODCalDesiredTolearance(Channel, Source, PowerDesiredTolerance, MODCalTypeEnum.POWer);
-            }
-
-            PNAX.MODCalEnable(Channel, Source, EqualizationEnableCal, MODCalTypeEnum.EQUalization);
-            if (EqualizationEnableCal)
-            {
-                PNAX.MODCalPort(Channel, Source, EqualizationCalPort, MODCalTypeEnum.EQUalization);
-                PNAX.MODCalSpan(Channel, Source, EqualizationCalSpan, MODCalTypeEnum.EQUalization);
-                PNAX.MODCalMaxIterations(Channel, Source, EqualizationMaxIterations, MODCalTypeEnum.EQUalization);
-                PNAX.MODCalDesiredTolearance(Channel, Source, EqualizationDesiredTolerance, MODCalTypeEnum.EQUalization);
-            }
-
-            PNAX.MODCalEnable(Channel, Source, DistortionEnableCal, MODCalTypeEnum.DISTortion);
-            if (DistortionEnableCal)
-            {
-                PNAX.MODCalPort(Channel, Source, DistortionCalPort, MODCalTypeEnum.DISTortion);
-                PNAX.MODCalSpan(Channel, Source, DistortionCalSpan, MODCalTypeEnum.DISTortion);
-                PNAX.MODCalMaxIterations(Channel, Source, DistortionMaxIterations, MODCalTypeEnum.DISTortion);
-                PNAX.MODCalDesiredTolearance(Channel, Source, DistortionDesiredTolerance, MODCalTypeEnum.DISTortion);
-            }
-
-            PNAX.MODCalEnable(Channel, Source, ACPLowerEnableCal, MODCalTypeEnum.ACPLower);
-            if (ACPLowerEnableCal)
-            {
-                PNAX.MODCalPort(Channel, Source, ACPLowerCalPort, MODCalTypeEnum.ACPLower);
-                PNAX.MODCalSpan(Channel, Source, ACPLowerCalSpan, MODCalTypeEnum.ACPLower);
-                PNAX.MODCalGuardBand(Channel, Source, ACPLowerGuardBand, MODCalTypeEnum.ACPLower);
-                PNAX.MODCalMaxIterations(Channel, Source, ACPLowerMaxIterations, MODCalTypeEnum.ACPLower);
-                PNAX.MODCalDesiredTolearance(Channel, Source, ACPLowerDesiredTolerance, MODCalTypeEnum.ACPLower);
-            }
-
-            PNAX.MODCalEnable(Channel, Source, ACPUpperEnableCal, MODCalTypeEnum.ACPUpper);
-            if (ACPUpperEnableCal)
-            {
-                PNAX.MODCalPort(Channel, Source, ACPUpperCalPort, MODCalTypeEnum.ACPUpper);
-                PNAX.MODCalSpan(Channel, Source, ACPUpperCalSpan, MODCalTypeEnum.ACPUpper);
-                PNAX.MODCalGuardBand(Channel, Source, ACPUpperGuardBand, MODCalTypeEnum.ACPUpper);
-                PNAX.MODCalMaxIterations(Channel, Source, ACPUpperMaxIterations, MODCalTypeEnum.ACPUpper);
-                PNAX.MODCalDesiredTolearance(Channel, Source, ACPUpperDesiredTolerance, MODCalTypeEnum.ACPUpper);
-            }
-
-
-            PNAX.WaitForOperationComplete();
-
-            // Execute Calibration
-            PNAX.MODCalibrationMeasure(Channel, Source);
-            //PNAX.WaitForOperationComplete(60000);
-            // Calibration details returns multiple single responses, using SCPIQuery leaves multiple lines on the queue
-            // Better not to use Calibration Details for now
-            //Log.Info("MOD Calibration Details: " + PNAX.MODGetCalibrationDetails(Channel, Source)); 
-            Log.Info("MOD Calibration Status: " + PNAX.MODGetCalibrationStatus(Channel, Source));
-
-            // Source Correction
-            PNAX.MODSourceCorrection(Channel, Source, ModSourceCorrection);
 
             UpgradeVerdict(Verdict.Pass);
         }

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODModulate.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODModulate.cs
@@ -1,0 +1,276 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+    
+    [AllowAsChildIn(typeof(TestPlan))]
+    [AllowAsChildIn(typeof(MODChannel))]
+    [Display("Modulation", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
+    public class MODModulate : PNABaseStep
+    {
+        #region Settings
+
+        [Display("Source", Group: "Settings", Order: 10)]
+        public String Source { get; set; }
+
+        [Display("Modulation File", Group: "Settings", Order: 11)]
+        public String ModulationFile { get; set; }
+
+        [Display("Enable Modulation", Group: "Settings", Order: 12)]
+        public bool EnableModulation { get; set; }
+
+        [Display("Source Correction", Group: "Settings", Order: 13)]
+        public MODSourceCorrectionEnum ModSourceCorrection { get; set; }
+
+        [Display("Enable Cal", Group: "Modulation Cal \\ Power", Order: 21)]
+        public bool PowerEnableCal { get; set; }
+
+        [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Port", Group: "Modulation Cal \\ Power", Order: 22)]
+        public MODCalPortEnum PowerCalPort { get; set; }
+
+        [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Span", Group: "Modulation Cal \\ Power", Order: 23)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double PowerCalSpan { get; set; }
+
+        [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Max Iterations", Group: "Modulation Cal \\ Power", Order: 24)]
+        public int PowerMaxIterations { get; set; }
+
+        [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Desired Tolerance", Group: "Modulation Cal \\ Power", Order: 25)]
+        [Unit("dB", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double PowerDesiredTolerance { get; set; }
+
+
+        [Display("Enable Cal", Group: "Modulation Cal \\ Equalization", Order: 31)]
+        public bool EqualizationEnableCal { get; set; }
+
+        [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Port", Group: "Modulation Cal \\ Equalization", Order: 32)]
+        public MODCalPortEnum EqualizationCalPort { get; set; }
+
+        [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Span", Group: "Modulation Cal \\ Equalization", Order: 33)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double EqualizationCalSpan { get; set; }
+
+        [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
+        [Display("Max Iterations", Group: "Modulation Cal \\ Equalization", Order: 34)]
+        public int EqualizationMaxIterations { get; set; }
+
+        [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
+        [Display("Desired Tolerance", Group: "Modulation Cal \\ Equalization", Order: 35)]
+        [Unit("dB-pk", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double EqualizationDesiredTolerance { get; set; }
+
+
+
+        [Display("Enable Cal", Group: "Modulation Cal \\ Distortion", Order: 41)]
+        public bool DistortionEnableCal { get; set; }
+
+        [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Port", Group: "Modulation Cal \\ Distortion", Order: 42)]
+        public MODCalPortEnum DistortionCalPort { get; set; }
+
+        [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Span", Group: "Modulation Cal \\ Distortion", Order: 43)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double DistortionCalSpan { get; set; }
+
+        [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
+        [Display("Max Iterations", Group: "Modulation Cal \\ Distortion", Order: 44)]
+        public int DistortionMaxIterations { get; set; }
+
+        [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
+        [Display("Desired Tolerance", Group: "Modulation Cal \\ Distortion", Order: 45)]
+        [Unit("dBc", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double DistortionDesiredTolerance { get; set; }
+
+
+
+        [Display("Enable Cal", Group: "Modulation Cal \\ ACP Lower", Order: 51)]
+        public bool ACPLowerEnableCal { get; set; }
+
+        [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Port", Group: "Modulation Cal \\ ACP Lower", Order: 52)]
+        public MODCalPortEnum ACPLowerCalPort { get; set; }
+
+        [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Span", Group: "Modulation Cal \\ ACP Lower", Order: 53)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double ACPLowerCalSpan { get; set; }
+
+        [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Guard Band", Group: "Modulation Cal \\ ACP Lower", Order: 53.5)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double ACPLowerGuardBand { get; set; }
+
+        [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Max Iterations", Group: "Modulation Cal \\ ACP Lower", Order: 54)]
+        public int ACPLowerMaxIterations { get; set; }
+
+        [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Desired Tolerance", Group: "Modulation Cal \\ ACP Lower", Order: 55)]
+        [Unit("dBc", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double ACPLowerDesiredTolerance { get; set; }
+
+
+
+        [Display("Enable Cal", Group: "Modulation Cal \\ ACP Upper", Order: 61)]
+        public bool ACPUpperEnableCal { get; set; }
+
+        [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Port", Group: "Modulation Cal \\ ACP Upper", Order: 62)]
+        public MODCalPortEnum ACPUpperCalPort { get; set; }
+
+        [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Span", Group: "Modulation Cal \\ ACP Upper", Order: 63)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double ACPUpperCalSpan { get; set; }
+
+        [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
+        [Display("Guard Band", Group: "Modulation Cal \\ ACP Upper", Order: 53.5)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double ACPUpperGuardBand { get; set; }
+
+        [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
+        [Display("Max Iterations", Group: "Modulation Cal \\ ACP Upper", Order: 64)]
+        public int ACPUpperMaxIterations { get; set; }
+
+        [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
+        [Display("Desired Tolerance", Group: "Modulation Cal \\ ACP Upper", Order: 65)]
+        [Unit("dBc", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double ACPUpperDesiredTolerance { get; set; }
+        #endregion
+
+        public MODModulate()
+        {
+            Source = "Port 1";
+            ModulationFile = @"D:\data\d.mdx";
+            EnableModulation = false;
+            ModSourceCorrection = MODSourceCorrectionEnum.OFF;
+
+            PowerEnableCal = true;
+            PowerCalPort = MODCalPortEnum.DUTIn1;
+            PowerCalSpan = 135.166667e6;
+            PowerMaxIterations = 3;
+            PowerDesiredTolerance = 0.1;
+
+            EqualizationEnableCal = true;
+            EqualizationCalPort = MODCalPortEnum.DUTIn1;
+            EqualizationCalSpan = 135.166667e6;
+            EqualizationMaxIterations = 3;
+            EqualizationDesiredTolerance = 0.3;
+
+            DistortionEnableCal = false;
+            DistortionCalPort = MODCalPortEnum.DUTIn1;
+            DistortionCalSpan = 135.166667e6;
+            DistortionMaxIterations = 3;
+            DistortionDesiredTolerance = -40;
+
+            ACPLowerEnableCal = false;
+            ACPLowerCalPort = MODCalPortEnum.DUTIn1;
+            ACPLowerCalSpan = 16.916667e6;
+            ACPLowerGuardBand = 0;
+            ACPLowerMaxIterations = 2;
+            ACPLowerDesiredTolerance = -40;
+
+            ACPUpperEnableCal = false;
+            ACPUpperCalPort = MODCalPortEnum.DUTIn1;
+            ACPUpperCalSpan = 16.916667e6;
+            ACPUpperGuardBand = 0;
+            ACPUpperMaxIterations = 2;
+            ACPUpperDesiredTolerance = -40;
+
+
+
+        }
+
+        public override void Run()
+        {
+            RunChildSteps(); //If the step supports child steps.
+
+            PNAX.SetMODSource(Channel, Source);
+            PNAX.MODLoadFile(Channel, Source, ModulationFile);
+            PNAX.MODEnableModulation(Channel, Source, EnableModulation);
+            PNAX.WaitForOperationComplete();
+
+
+            PNAX.WaitForOperationComplete();
+
+            PNAX.MODCalEnable(Channel, Source, PowerEnableCal, MODCalTypeEnum.POWer);
+            if (PowerEnableCal)
+            {
+                PNAX.MODCalPort(Channel, Source, PowerCalPort, MODCalTypeEnum.POWer);
+                PNAX.MODCalSpan(Channel, Source, PowerCalSpan, MODCalTypeEnum.POWer);
+                PNAX.MODCalMaxIterations(Channel, Source, PowerMaxIterations, MODCalTypeEnum.POWer);
+                PNAX.MODCalDesiredTolearance(Channel, Source, PowerDesiredTolerance, MODCalTypeEnum.POWer);
+            }
+
+            PNAX.MODCalEnable(Channel, Source, EqualizationEnableCal, MODCalTypeEnum.EQUalization);
+            if (EqualizationEnableCal)
+            {
+                PNAX.MODCalPort(Channel, Source, EqualizationCalPort, MODCalTypeEnum.EQUalization);
+                PNAX.MODCalSpan(Channel, Source, EqualizationCalSpan, MODCalTypeEnum.EQUalization);
+                PNAX.MODCalMaxIterations(Channel, Source, EqualizationMaxIterations, MODCalTypeEnum.EQUalization);
+                PNAX.MODCalDesiredTolearance(Channel, Source, EqualizationDesiredTolerance, MODCalTypeEnum.EQUalization);
+            }
+
+            PNAX.MODCalEnable(Channel, Source, DistortionEnableCal, MODCalTypeEnum.DISTortion);
+            if (DistortionEnableCal)
+            {
+                PNAX.MODCalPort(Channel, Source, DistortionCalPort, MODCalTypeEnum.DISTortion);
+                PNAX.MODCalSpan(Channel, Source, DistortionCalSpan, MODCalTypeEnum.DISTortion);
+                PNAX.MODCalMaxIterations(Channel, Source, DistortionMaxIterations, MODCalTypeEnum.DISTortion);
+                PNAX.MODCalDesiredTolearance(Channel, Source, DistortionDesiredTolerance, MODCalTypeEnum.DISTortion);
+            }
+
+            PNAX.MODCalEnable(Channel, Source, ACPLowerEnableCal, MODCalTypeEnum.ACPLower);
+            if (ACPLowerEnableCal)
+            {
+                PNAX.MODCalPort(Channel, Source, ACPLowerCalPort, MODCalTypeEnum.ACPLower);
+                PNAX.MODCalSpan(Channel, Source, ACPLowerCalSpan, MODCalTypeEnum.ACPLower);
+                PNAX.MODCalGuardBand(Channel, Source, ACPLowerGuardBand, MODCalTypeEnum.ACPLower);
+                PNAX.MODCalMaxIterations(Channel, Source, ACPLowerMaxIterations, MODCalTypeEnum.ACPLower);
+                PNAX.MODCalDesiredTolearance(Channel, Source, ACPLowerDesiredTolerance, MODCalTypeEnum.ACPLower);
+            }
+
+            PNAX.MODCalEnable(Channel, Source, ACPUpperEnableCal, MODCalTypeEnum.ACPUpper);
+            if (ACPUpperEnableCal)
+            {
+                PNAX.MODCalPort(Channel, Source, ACPUpperCalPort, MODCalTypeEnum.ACPUpper);
+                PNAX.MODCalSpan(Channel, Source, ACPUpperCalSpan, MODCalTypeEnum.ACPUpper);
+                PNAX.MODCalGuardBand(Channel, Source, ACPUpperGuardBand, MODCalTypeEnum.ACPUpper);
+                PNAX.MODCalMaxIterations(Channel, Source, ACPUpperMaxIterations, MODCalTypeEnum.ACPUpper);
+                PNAX.MODCalDesiredTolearance(Channel, Source, ACPUpperDesiredTolerance, MODCalTypeEnum.ACPUpper);
+            }
+
+
+            PNAX.WaitForOperationComplete();
+
+            // Execute Calibration
+            PNAX.MODCalibrationMeasure(Channel, Source);
+            //PNAX.WaitForOperationComplete(60000);
+            Log.Info("MOD Calibration Details: " + PNAX.MODGetCalibrationDetails(Channel, Source));
+            Log.Info("MOD Calibration Status: " + PNAX.MODGetCalibrationStatus(Channel, Source));
+
+            // Source Correction
+            PNAX.MODSourceCorrection(Channel, Source, ModSourceCorrection);
+
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODModulate.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODModulate.cs
@@ -16,6 +16,7 @@ namespace OpenTap.Plugins.PNAX
     
     [AllowAsChildIn(typeof(TestPlan))]
     [AllowAsChildIn(typeof(MODChannel))]
+    [AllowAsChildIn(typeof(MODXChannel))]
     [Display("MOD Modulation", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
     public class MODModulate : PNABaseStep
     {

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODNewTrace.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODNewTrace.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODNewTrace.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODNewTrace.cs
@@ -29,6 +29,14 @@ namespace OpenTap.Plugins.PNAX
             ChildTestSteps.Add(new MODSingleTrace() { PNAX = this.PNAX, Meas = this.Meas, Channel = this.Channel, IsControlledByParent = true, EnableTraceSettings = true });
         }
 
+        [Browsable(false)]
+        public override List<(string, object)> GetMetaData()
+        {
+            List<(string, object)> retVal = new List<(string, object)>();
+
+            return retVal;
+        }
+
         protected override void DeleteDummyTrace()
         {
             PNAX.ScpiCommand($"CALCulate{Channel}:PARameter:DELete \'CH{Channel}_DUMMY_1\'");

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODNewTrace.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODNewTrace.cs
@@ -1,0 +1,42 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+    [AllowAsChildIn(typeof(MODChannel))]
+    [AllowChildrenOfType(typeof(MODSingleTrace))]
+    [Display("Modulation Distortion New Trace", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
+    public class MODNewTrace : AddNewTraceBaseStep
+    {
+        #region Settings
+        [Display("Meas", Groups: new[] { "Trace" }, Order: 11)]
+        public MODTraceEnum Meas { get; set; }
+        #endregion
+
+        public MODNewTrace()
+        {
+            Meas = MODTraceEnum.PIn1;
+            ChildTestSteps.Add(new MODSingleTrace() { PNAX = this.PNAX, Meas = this.Meas, Channel = this.Channel, IsControlledByParent = true, EnableTraceSettings = true });
+        }
+
+        protected override void DeleteDummyTrace()
+        {
+            PNAX.ScpiCommand($"CALCulate{Channel}:PARameter:DELete \'CH{Channel}_DUMMY_1\'");
+        }
+
+        protected override void AddNewTrace()
+        {
+            ChildTestSteps.Add(new MODSingleTrace() { PNAX = this.PNAX, Meas = this.Meas, Channel = this.Channel, IsControlledByParent = true, EnableTraceSettings = true });
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODRFPath.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODRFPath.cs
@@ -69,6 +69,23 @@ namespace OpenTap.Plugins.PNAX
             NominalDUTNF = 0;
         }
 
+        [Browsable(false)]
+        public override List<(string, object)> GetMetaData()
+        {
+            List<(string, object)> retVal = new List<(string, object)>();
+            retVal.Add(("IncludeSourceAtt", IncludeSourceAtt));
+            retVal.Add(("SourceAttenuator", SourceAttenuator));
+            retVal.Add(("NominalSourceAmp", NominalSourceAmp));
+            retVal.Add(("DUTInput", DUTInput));
+            retVal.Add(("NominalDUTGain", NominalDUTGain));
+            retVal.Add(("DUTOutput", DUTOutput));
+            retVal.Add(("ReceiverAttenuator", ReceiverAttenuator));
+            retVal.Add(("IncludeNominalDUTNF", IncludeNominalDUTNF));
+            retVal.Add(("NominalDUTNF", NominalDUTNF));
+
+            return retVal;
+        }
+
         public override void Run()
         {
             RunChildSteps(); //If the step supports child steps.

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODRFPath.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODRFPath.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODRFPath.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODRFPath.cs
@@ -1,0 +1,89 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+    [AllowAsChildIn(typeof(TestPlan))]
+    [AllowAsChildIn(typeof(MODChannel))]
+    [Display("MOD RF Path", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
+    public class MODRFPath : PNABaseStep
+    {
+        #region Settings
+        [Display("Include Source Attenuator", Group: "Settings", Order: 10)]
+        public bool IncludeSourceAtt { get; set; }
+
+        [EnabledIf("IncludeSourceAtt", true, HideIfDisabled = true)]
+        [Display("Source Attenuator", Group: "Settings", Order: 11)]
+        [Unit("dB", UseEngineeringPrefix: false, StringFormat: "0")]
+        public double SourceAttenuator { get; set; }
+
+        [Display("Nominal Source Amplifier", Group: "Settings", Order: 12)]
+        [Unit("dB", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double NominalSourceAmp { get; set; }
+
+        [Display("DUT Input", Group: "Settings", Order: 13)]
+        public MODDutPortEnum DUTInput { get; set; }
+
+        [Display("Nominal DUT Gain", Group: "Settings", Order: 14)]
+        [Unit("dB", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double NominalDUTGain { get; set; }
+
+        [Display("DUT Output", Group: "Settings", Order: 15)]
+        public MODDutPortEnum DUTOutput { get; set; }
+
+        [Display("Receiver Attenuator", Group: "Settings", Order: 16)]
+        [Unit("dB", UseEngineeringPrefix: false, StringFormat: "0")]
+        public double ReceiverAttenuator { get; set; }
+
+        [Display("Include Nominal DUT NF", Group: "Settings", Order: 17)]
+        public bool IncludeNominalDUTNF { get; set; }
+
+        [EnabledIf("IncludeNominalDUTNF", true, HideIfDisabled = true)]
+        [Display("Nominal DUT NF", Group: "Settings", Order: 18)]
+        [Unit("dB", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double NominalDUTNF { get; set; }
+
+        #endregion
+
+        public MODRFPath()
+        {
+            IncludeSourceAtt = true;
+            SourceAttenuator = 0;
+            NominalSourceAmp = 0;
+            DUTInput = MODDutPortEnum.Port1;
+            NominalDUTGain = 0;
+            DUTOutput = MODDutPortEnum.Port2;
+            ReceiverAttenuator = 18;
+            IncludeNominalDUTNF = false;
+            NominalDUTNF = 0;
+        }
+
+        public override void Run()
+        {
+            RunChildSteps(); //If the step supports child steps.
+
+            PNAX.MODSourceAttenuatorInclude(Channel, IncludeSourceAtt);
+            if (IncludeSourceAtt) PNAX.MODSourceAttenuator(Channel, SourceAttenuator, DUTInput);
+            PNAX.MODNominalSource(Channel, NominalSourceAmp);
+            PNAX.MODDutInput(Channel, DUTInput);
+            PNAX.MODNominalDUTGain(Channel, NominalDUTGain);
+            PNAX.MODDutOutput(Channel, DUTOutput);
+            PNAX.MODReceiverAttenuator(Channel, ReceiverAttenuator, DUTOutput);
+            PNAX.MODNominalDUTNFInclude(Channel, IncludeNominalDUTNF);
+            if (IncludeNominalDUTNF) PNAX.MODNominalDUTNF(Channel, NominalDUTNF);
+
+
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODRFPath.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODRFPath.cs
@@ -15,6 +15,7 @@ namespace OpenTap.Plugins.PNAX
 {
     [AllowAsChildIn(typeof(TestPlan))]
     [AllowAsChildIn(typeof(MODChannel))]
+    [AllowAsChildIn(typeof(MODXChannel))]
     [Display("MOD RF Path", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
     public class MODRFPath : PNABaseStep
     {

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSaveDistortionTable.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSaveDistortionTable.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSaveDistortionTable.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSaveDistortionTable.cs
@@ -1,0 +1,41 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+    [AllowAsChildIn(typeof(TestPlan))]
+    [AllowAsChildIn(typeof(MODChannel))]
+    [Display("MOD Save Distortion Table", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Specifies the file path to save a modulation distortion table file")]
+    public class MODSaveDistortionTable : PNABaseStep
+    {
+        #region Settings
+        [Display("Modulation Distortion File", Group: "Settings", Order: 11)]
+        public String ModulationDistortionFile { get; set; }
+
+        #endregion
+
+        public MODSaveDistortionTable()
+        {
+            ModulationDistortionFile = "myModDistortionTable.csv";
+        }
+
+        public override void Run()
+        {
+            RunChildSteps(); //If the step supports child steps.
+
+            PNAX.MODSaveDistortionTable(Channel, ModulationDistortionFile);
+
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSingleTrace.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSingleTrace.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSingleTrace.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSingleTrace.cs
@@ -1,0 +1,70 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+
+    public enum MODTraceEnum
+    {
+        PIn1,
+        PInWav,
+        POut1,
+        Pout2,
+        PDlvrIn1,
+        PDlvrOut2,
+        DutNois2,
+        MSig2,
+        MDist2,
+        MGain21,
+        PGain21,
+        LMatch2,
+        CarrIn1,
+        CarrOut2,
+        CarrGain21
+    }
+
+
+    [AllowAsChildIn(typeof(MODNewTrace))]
+    [Display("Modulation Distortion Single Trace", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
+    public class MODSingleTrace : SingleTraceBaseStep
+    {
+        #region Settings
+        private MODTraceEnum _Meas;
+
+        [EnabledIf(nameof(CustomTraceMeas), false, HideIfDisabled = true)]
+        [Display("Meas", Groups: new[] { "Trace" }, Order: 11.1)]
+        public MODTraceEnum Meas
+        {
+            get
+            {
+                return _Meas;
+            }
+            set
+            {
+                _Meas = value;
+                string scpi = Scpi.Format("{0}", value);
+                measEnumName = scpi;    // value.ToString();
+                UpdateTestStepName();
+            }
+        }
+
+        #endregion
+
+        public MODSingleTrace()
+        {
+            Meas = MODTraceEnum.PIn1;
+            measClass = "Modulation Distortion";
+        }
+
+    }
+}

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSourceCorrection.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSourceCorrection.cs
@@ -1,0 +1,260 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+
+    [AllowAsChildIn(typeof(TestPlan))]
+    [AllowAsChildIn(typeof(MODChannel))]
+    [Display("MOD Source Correction", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
+    public class MODSourceCorrection : PNABaseStep
+    {
+        #region Settings
+        [Display("Source", Group: "Settings", Order: 10)]
+        public String Source { get; set; }
+
+        [Display("Source Correction", Group: "Settings", Order: 13)]
+        public MODSourceCorrectionEnum ModSourceCorrection { get; set; }
+
+        [Display("Enable Cal", Groups: new[] { "Modulation Cal", "Power" }, Order: 21)]
+        public bool PowerEnableCal { get; set; }
+
+        [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Port", Groups: new[] { "Modulation Cal", "Power" }, Order: 22)]
+        public MODCalPortEnum PowerCalPort { get; set; }
+
+        [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Span", Groups: new[] { "Modulation Cal", "Power" }, Order: 23)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double PowerCalSpan { get; set; }
+
+        [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Max Iterations", Groups: new[] { "Modulation Cal", "Power" }, Order: 24)]
+        public int PowerMaxIterations { get; set; }
+
+        [EnabledIf("PowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Desired Tolerance", Groups: new[] { "Modulation Cal", "Power" }, Order: 25)]
+        [Unit("dB", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double PowerDesiredTolerance { get; set; }
+
+
+        [Display("Enable Cal", Groups: new[] { "Modulation Cal", "Equalization" }, Order: 31)]
+        public bool EqualizationEnableCal { get; set; }
+
+        [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Port", Groups: new[] { "Modulation Cal", "Equalization" }, Order: 32)]
+        public MODCalPortEnum EqualizationCalPort { get; set; }
+
+        [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Span", Groups: new[] { "Modulation Cal", "Equalization" }, Order: 33)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double EqualizationCalSpan { get; set; }
+
+        [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
+        [Display("Max Iterations", Groups: new[] { "Modulation Cal", "Equalization" }, Order: 34)]
+        public int EqualizationMaxIterations { get; set; }
+
+        [EnabledIf("EqualizationEnableCal", true, HideIfDisabled = true)]
+        [Display("Desired Tolerance", Groups: new[] { "Modulation Cal", "Equalization" }, Order: 35)]
+        [Unit("dB-pk", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double EqualizationDesiredTolerance { get; set; }
+
+
+
+        [Display("Enable Cal", Groups: new[] { "Modulation Cal", "Distortion" }, Order: 41)]
+        public bool DistortionEnableCal { get; set; }
+
+        [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Port", Groups: new[] { "Modulation Cal", "Distortion" }, Order: 42)]
+        public MODCalPortEnum DistortionCalPort { get; set; }
+
+        [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Span", Groups: new[] { "Modulation Cal", "Distortion" }, Order: 43)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double DistortionCalSpan { get; set; }
+
+        [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
+        [Display("Max Iterations", Groups: new[] { "Modulation Cal", "Distortion" }, Order: 44)]
+        public int DistortionMaxIterations { get; set; }
+
+        [EnabledIf("DistortionEnableCal", true, HideIfDisabled = true)]
+        [Display("Desired Tolerance", Groups: new[] { "Modulation Cal", "Distortion" }, Order: 45)]
+        [Unit("dBc", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double DistortionDesiredTolerance { get; set; }
+
+
+
+        [Display("Enable Cal", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 51)]
+        public bool ACPLowerEnableCal { get; set; }
+
+        [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Port", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 52)]
+        public MODCalPortEnum ACPLowerCalPort { get; set; }
+
+        [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Span", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 53)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double ACPLowerCalSpan { get; set; }
+
+        [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Guard Band", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 53.5)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double ACPLowerGuardBand { get; set; }
+
+        [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Max Iterations", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 54)]
+        public int ACPLowerMaxIterations { get; set; }
+
+        [EnabledIf("ACPLowerEnableCal", true, HideIfDisabled = true)]
+        [Display("Desired Tolerance", Groups: new[] { "Modulation Cal", "ACP Lower" }, Order: 55)]
+        [Unit("dBc", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double ACPLowerDesiredTolerance { get; set; }
+
+
+
+        [Display("Enable Cal", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 61)]
+        public bool ACPUpperEnableCal { get; set; }
+
+        [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Port", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 62)]
+        public MODCalPortEnum ACPUpperCalPort { get; set; }
+
+        [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
+        [Display("Cal Span", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 63)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double ACPUpperCalSpan { get; set; }
+
+        [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
+        [Display("Guard Band", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 53.5)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double ACPUpperGuardBand { get; set; }
+
+        [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
+        [Display("Max Iterations", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 64)]
+        public int ACPUpperMaxIterations { get; set; }
+
+        [EnabledIf("ACPUpperEnableCal", true, HideIfDisabled = true)]
+        [Display("Desired Tolerance", Groups: new[] { "Modulation Cal", "ACP Upper" }, Order: 65)]
+        [Unit("dBc", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double ACPUpperDesiredTolerance { get; set; }
+        #endregion
+
+        public MODSourceCorrection()
+        {
+            Source = "Port 1";
+            ModSourceCorrection = MODSourceCorrectionEnum.OFF;
+
+            PowerEnableCal = true;
+            PowerCalPort = MODCalPortEnum.DUTIn1;
+            PowerCalSpan = 135.166667e6;
+            PowerMaxIterations = 3;
+            PowerDesiredTolerance = 0.1;
+
+            EqualizationEnableCal = true;
+            EqualizationCalPort = MODCalPortEnum.DUTIn1;
+            EqualizationCalSpan = 135.166667e6;
+            EqualizationMaxIterations = 3;
+            EqualizationDesiredTolerance = 0.3;
+
+            DistortionEnableCal = false;
+            DistortionCalPort = MODCalPortEnum.DUTIn1;
+            DistortionCalSpan = 135.166667e6;
+            DistortionMaxIterations = 3;
+            DistortionDesiredTolerance = -40;
+
+            ACPLowerEnableCal = false;
+            ACPLowerCalPort = MODCalPortEnum.DUTIn1;
+            ACPLowerCalSpan = 16.916667e6;
+            ACPLowerGuardBand = 0;
+            ACPLowerMaxIterations = 2;
+            ACPLowerDesiredTolerance = -40;
+
+            ACPUpperEnableCal = false;
+            ACPUpperCalPort = MODCalPortEnum.DUTIn1;
+            ACPUpperCalSpan = 16.916667e6;
+            ACPUpperGuardBand = 0;
+            ACPUpperMaxIterations = 2;
+            ACPUpperDesiredTolerance = -40;
+
+
+
+        }
+
+        public override void Run()
+        {
+            RunChildSteps(); //If the step supports child steps.
+
+            PNAX.MODCalEnable(Channel, Source, PowerEnableCal, MODCalTypeEnum.POWer);
+            if (PowerEnableCal)
+            {
+                PNAX.MODCalPort(Channel, Source, PowerCalPort, MODCalTypeEnum.POWer);
+                PNAX.MODCalSpan(Channel, Source, PowerCalSpan, MODCalTypeEnum.POWer);
+                PNAX.MODCalMaxIterations(Channel, Source, PowerMaxIterations, MODCalTypeEnum.POWer);
+                PNAX.MODCalDesiredTolearance(Channel, Source, PowerDesiredTolerance, MODCalTypeEnum.POWer);
+            }
+
+            PNAX.MODCalEnable(Channel, Source, EqualizationEnableCal, MODCalTypeEnum.EQUalization);
+            if (EqualizationEnableCal)
+            {
+                PNAX.MODCalPort(Channel, Source, EqualizationCalPort, MODCalTypeEnum.EQUalization);
+                PNAX.MODCalSpan(Channel, Source, EqualizationCalSpan, MODCalTypeEnum.EQUalization);
+                PNAX.MODCalMaxIterations(Channel, Source, EqualizationMaxIterations, MODCalTypeEnum.EQUalization);
+                PNAX.MODCalDesiredTolearance(Channel, Source, EqualizationDesiredTolerance, MODCalTypeEnum.EQUalization);
+            }
+
+            PNAX.MODCalEnable(Channel, Source, DistortionEnableCal, MODCalTypeEnum.DISTortion);
+            if (DistortionEnableCal)
+            {
+                PNAX.MODCalPort(Channel, Source, DistortionCalPort, MODCalTypeEnum.DISTortion);
+                PNAX.MODCalSpan(Channel, Source, DistortionCalSpan, MODCalTypeEnum.DISTortion);
+                PNAX.MODCalMaxIterations(Channel, Source, DistortionMaxIterations, MODCalTypeEnum.DISTortion);
+                PNAX.MODCalDesiredTolearance(Channel, Source, DistortionDesiredTolerance, MODCalTypeEnum.DISTortion);
+            }
+
+            PNAX.MODCalEnable(Channel, Source, ACPLowerEnableCal, MODCalTypeEnum.ACPLower);
+            if (ACPLowerEnableCal)
+            {
+                PNAX.MODCalPort(Channel, Source, ACPLowerCalPort, MODCalTypeEnum.ACPLower);
+                PNAX.MODCalSpan(Channel, Source, ACPLowerCalSpan, MODCalTypeEnum.ACPLower);
+                PNAX.MODCalGuardBand(Channel, Source, ACPLowerGuardBand, MODCalTypeEnum.ACPLower);
+                PNAX.MODCalMaxIterations(Channel, Source, ACPLowerMaxIterations, MODCalTypeEnum.ACPLower);
+                PNAX.MODCalDesiredTolearance(Channel, Source, ACPLowerDesiredTolerance, MODCalTypeEnum.ACPLower);
+            }
+
+            PNAX.MODCalEnable(Channel, Source, ACPUpperEnableCal, MODCalTypeEnum.ACPUpper);
+            if (ACPUpperEnableCal)
+            {
+                PNAX.MODCalPort(Channel, Source, ACPUpperCalPort, MODCalTypeEnum.ACPUpper);
+                PNAX.MODCalSpan(Channel, Source, ACPUpperCalSpan, MODCalTypeEnum.ACPUpper);
+                PNAX.MODCalGuardBand(Channel, Source, ACPUpperGuardBand, MODCalTypeEnum.ACPUpper);
+                PNAX.MODCalMaxIterations(Channel, Source, ACPUpperMaxIterations, MODCalTypeEnum.ACPUpper);
+                PNAX.MODCalDesiredTolearance(Channel, Source, ACPUpperDesiredTolerance, MODCalTypeEnum.ACPUpper);
+            }
+
+            PNAX.WaitForOperationComplete();
+
+            // Execute Calibration
+            PNAX.MODCalibrationMeasure(Channel, Source);
+
+            // Calibration details returns multiple single responses, using SCPIQuery leaves multiple lines on the queue
+            // Better not to use Calibration Details for now
+            //Log.Info("MOD Calibration Details: " + PNAX.MODGetCalibrationDetails(Channel, Source)); 
+            Log.Info("MOD Calibration Status: " + PNAX.MODGetCalibrationStatus(Channel, Source));
+
+            // Source Correction
+            PNAX.MODSourceCorrection(Channel, Source, ModSourceCorrection);
+
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSourceCorrection.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSourceCorrection.cs
@@ -186,9 +186,57 @@ namespace OpenTap.Plugins.PNAX
             ACPUpperGuardBand = 0;
             ACPUpperMaxIterations = 2;
             ACPUpperDesiredTolerance = -40;
+        }
 
-
-
+        [Browsable(false)]
+        public override List<(string, object)> GetMetaData()
+        {
+            List<(string, object)> retVal = new List<(string, object)>();
+            retVal.Add(("Source", Source));
+            retVal.Add(("ModSourceCorrection", ModSourceCorrection));
+            retVal.Add(("PowerEnableCal", PowerEnableCal));
+            if (PowerEnableCal)
+            {
+                retVal.Add(("PowerCalPort", PowerCalPort));
+                retVal.Add(("PowerCalSpan", PowerCalSpan));
+                retVal.Add(("PowerMaxIterations", PowerMaxIterations));
+                retVal.Add(("PowerDesiredTolerance", PowerDesiredTolerance));
+            }
+            retVal.Add(("EqualizationEnableCal", EqualizationEnableCal));
+            if (PowerEnableCal)
+            {
+                retVal.Add(("EqualizationCalPort", EqualizationCalPort));
+                retVal.Add(("EqualizationCalSpan", EqualizationCalSpan));
+                retVal.Add(("EqualizationMaxIterations", EqualizationMaxIterations));
+                retVal.Add(("EqualizationDesiredTolerance", EqualizationDesiredTolerance));
+            }
+            retVal.Add(("DistortionEnableCal", DistortionEnableCal));
+            if (PowerEnableCal)
+            {
+                retVal.Add(("DistortionCalPort", DistortionCalPort));
+                retVal.Add(("DistortionCalSpan", DistortionCalSpan));
+                retVal.Add(("DistortionMaxIterations", DistortionMaxIterations));
+                retVal.Add(("DistortionDesiredTolerance", DistortionDesiredTolerance));
+            }
+            retVal.Add(("ACPLowerEnableCal", ACPLowerEnableCal));
+            if (PowerEnableCal)
+            {
+                retVal.Add(("ACPLowerCalPort", ACPLowerCalPort));
+                retVal.Add(("ACPLowerCalSpan", ACPLowerCalSpan));
+                retVal.Add(("ACPLowerGuardBand", ACPLowerGuardBand));
+                retVal.Add(("ACPLowerMaxIterations", ACPLowerMaxIterations));
+                retVal.Add(("ACPLowerDesiredTolerance", ACPLowerDesiredTolerance));
+            }
+            retVal.Add(("ACPUpperEnableCal", ACPUpperEnableCal));
+            if (PowerEnableCal)
+            {
+                retVal.Add(("ACPUpperCalPort", ACPUpperCalPort));
+                retVal.Add(("ACPUpperCalSpan", ACPUpperCalSpan));
+                retVal.Add(("ACPUpperGuardBand", ACPUpperGuardBand));
+                retVal.Add(("ACPUpperMaxIterations", ACPUpperMaxIterations));
+                retVal.Add(("ACPUpperDesiredTolerance", ACPUpperDesiredTolerance));
+            }
+            return retVal;
         }
 
         public override void Run()

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSourceCorrection.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSourceCorrection.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSourceCorrection.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSourceCorrection.cs
@@ -241,6 +241,7 @@ namespace OpenTap.Plugins.PNAX
 
         public override void Run()
         {
+            UpgradeVerdict(Verdict.NotSet);
             RunChildSteps(); //If the step supports child steps.
 
             PNAX.MODCalEnable(Channel, Source, PowerEnableCal, MODCalTypeEnum.POWer);
@@ -298,12 +299,21 @@ namespace OpenTap.Plugins.PNAX
             // Calibration details returns multiple single responses, using SCPIQuery leaves multiple lines on the queue
             // Better not to use Calibration Details for now
             //Log.Info("MOD Calibration Details: " + PNAX.MODGetCalibrationDetails(Channel, Source)); 
-            Log.Info("MOD Calibration Status: " + PNAX.MODGetCalibrationStatus(Channel, Source));
+            String calStatus = PNAX.MODGetCalibrationStatus(Channel, Source);
+            Log.Info("MOD Calibration Status: " + calStatus);
 
-            // Source Correction
-            PNAX.MODSourceCorrection(Channel, Source, ModSourceCorrection);
+            if (calStatus.Equals("Calibration failed."))
+            {
+                //throw new Exception("Calibration Failed!");
+                UpgradeVerdict(Verdict.Fail);
+            }
+            else
+            {
+                // Source Correction
+                PNAX.MODSourceCorrection(Channel, Source, ModSourceCorrection);
 
-            UpgradeVerdict(Verdict.Pass);
+                UpgradeVerdict(Verdict.Pass);
+            } 
         }
     }
 }

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSourceCorrection.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSourceCorrection.cs
@@ -16,6 +16,7 @@ namespace OpenTap.Plugins.PNAX
 
     [AllowAsChildIn(typeof(TestPlan))]
     [AllowAsChildIn(typeof(MODChannel))]
+    [AllowAsChildIn(typeof(MODXChannel))]
     [Display("MOD Source Correction", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
     public class MODSourceCorrection : PNABaseStep
     {

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSweep.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSweep.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSweep.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSweep.cs
@@ -1,0 +1,104 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+    [AllowAsChildIn(typeof(TestPlan))]
+    [AllowAsChildIn(typeof(MODChannel))]
+    [Display("MOD Sweep", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
+    public class MODSweep : PNABaseStep
+    {
+        #region Settings
+        [Display("Sweep Type", Group: "Sweep Settings", Order: 10)]
+        public MODSweepTypeEnum MODSweepType { get; set; }
+
+        [Display("Carrier Frequency", Group: "Sweep Settings", Order: 11)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double CarrierFrequency { get; set; }
+
+        [Display("Span", Group: "Sweep Settings", Order: 12)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double Span { get; set; }
+
+        [Display("Noise BW", Group: "Sweep Settings", Order: 13)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0")]
+        public int NoiseBW { get; set; }
+
+        [Display("Power Port", Group: "Sweep Settings", Order: 14)]
+        public MODPowerPortEnum PowerPort { get; set; }
+
+        [EnabledIf("MODSweepType", MODSweepTypeEnum.Fixed, HideIfDisabled = true)]
+        [Display("Power", Group: "Sweep Settings", Order: 15)]
+        [Unit("dBm", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double MODPower { get; set; }
+
+        [EnabledIf("MODSweepType", MODSweepTypeEnum.Power, HideIfDisabled = true)]
+        [Display("Start Power", Group: "Sweep Settings", Order: 16)]
+        [Unit("dBm", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double MODStartPower { get; set; }
+
+        [EnabledIf("MODSweepType", MODSweepTypeEnum.Power, HideIfDisabled = true)]
+        [Display("Stop Power", Group: "Sweep Settings", Order: 17)]
+        [Unit("dBm", UseEngineeringPrefix: false, StringFormat: "0.00")]
+        public double MODStopPower { get; set; }
+
+        [EnabledIf("MODSweepType", MODSweepTypeEnum.Power, HideIfDisabled = true)]
+        [Display("Number of Points", Group: "Sweep Settings", Order: 18)]
+        public int NumberOfPoints { get; set; }
+
+        [EnabledIf("MODSweepType", MODSweepTypeEnum.Power, HideIfDisabled = true)]
+        [Display("Auto-Increase NBW", Group: "Sweep Settings", Order: 19)]
+        public bool AutoIncreaseNBW { get; set; }
+
+        #endregion
+
+        public MODSweep()
+        {
+            MODSweepType = MODSweepTypeEnum.Fixed;
+            CarrierFrequency = 1.5e9;
+            Span = 300e6;
+            NoiseBW = 100;
+            PowerPort = MODPowerPortEnum.Din;
+            MODPower = -10;
+
+            MODStartPower = -20;
+            MODStopPower = -10;
+            NumberOfPoints = 11;
+            AutoIncreaseNBW = false;
+        }
+
+        public override void Run()
+        {
+            RunChildSteps(); //If the step supports child steps.
+
+            PNAX.MODSweepType(Channel, MODSweepType);
+
+            PNAX.MODCarrierFreq(Channel, CarrierFrequency);
+            PNAX.MODSpan(Channel, Span);
+            PNAX.MODNoiseBW(Channel, NoiseBW);
+            PNAX.MODSetPowerPort(Channel, PowerPort);
+            PNAX.MODSetPower(Channel, MODPower);
+
+            if (MODSweepType == MODSweepTypeEnum.Power)
+            {
+                PNAX.MODPowerSweepStart(Channel, MODStartPower);
+                PNAX.MODPowerSweepStop(Channel, MODStopPower);
+                PNAX.MODPowerSweepNumberOfPoints(Channel, NumberOfPoints);
+                PNAX.MODPowerSweepNoiseBW(Channel, NoiseBW);
+                PNAX.MODPowerSweepAutoIncreaseBW(Channel, AutoIncreaseNBW);
+            }
+
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSweep.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSweep.cs
@@ -15,6 +15,7 @@ namespace OpenTap.Plugins.PNAX
 {
     [AllowAsChildIn(typeof(TestPlan))]
     [AllowAsChildIn(typeof(MODChannel))]
+    [AllowAsChildIn(typeof(MODXChannel))]
     [Display("MOD Sweep", Groups: new[] { "Network Analyzer", "General", "Modulation Distortion" }, Description: "Insert a description here")]
     public class MODSweep : PNABaseStep
     {

--- a/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSweep.cs
+++ b/OpenTap.Plugins.PNAX/General/Modulation Distortion/MODSweep.cs
@@ -78,6 +78,27 @@ namespace OpenTap.Plugins.PNAX
             AutoIncreaseNBW = false;
         }
 
+        [Browsable(false)]
+        public override List<(string, object)> GetMetaData()
+        {
+            List<(string, object)> retVal = new List<(string, object)>();
+            retVal.Add(("SweepType", MODSweepType));
+            retVal.Add(("CarrierFrequency", CarrierFrequency));
+            retVal.Add(("Span", Span));
+            retVal.Add(("NoiseBW", NoiseBW));
+            retVal.Add(("PowerPort", PowerPort));
+            retVal.Add(("Power", MODPower));
+            if (MODSweepType == MODSweepTypeEnum.Power)
+            {
+                retVal.Add(("StartPower", MODStartPower));
+                retVal.Add(("StopPower", MODStopPower));
+                retVal.Add(("NumberOfPoints", NumberOfPoints));
+                retVal.Add(("AutoIncreaseNBW", AutoIncreaseNBW));
+            }
+
+            return retVal;
+        }
+
         public override void Run()
         {
             RunChildSteps(); //If the step supports child steps.

--- a/OpenTap.Plugins.PNAX/General/Standard/SweepType.cs
+++ b/OpenTap.Plugins.PNAX/General/Standard/SweepType.cs
@@ -190,7 +190,6 @@ namespace OpenTap.Plugins.PNAX
             switch (StandardSweepType)
             {
                 case StandardSweepTypeEnum.LinearFrequency:
-                    break;
                 case StandardSweepTypeEnum.LogFrequency:
                     retVal.Add(("Start", SweepPropertiesStart));
                     retVal.Add(("Stop", SweepPropertiesStop));
@@ -212,7 +211,6 @@ namespace OpenTap.Plugins.PNAX
                     retVal.Add(("IF Bandwidth", SweepPropertiesIFBandwidth));
                     break;
                 case StandardSweepTypeEnum.SegmentSweep:
-                    break;
                 case StandardSweepTypeEnum.PhaseSweep:
                     retVal.Add(("Start Phase", SweepPropertiesStartPhase));
                     retVal.Add(("Stop Phase", SweepPropertiesStopPhase));

--- a/OpenTap.Plugins.PNAX/Instrument/PNA.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNA.cs
@@ -322,8 +322,13 @@ namespace OpenTap.Plugins.PNAX
 
         public void SetSweepMode(int Channel, SweepModeEnumType sweepMode)
         {
+            int deftimeout = IoTimeout;
+            IoTimeout = 60000;
+
             string scpi = Scpi.Format("{0}", sweepMode);
             ScpiCommand($"SENSe{Channel}:SWEep:MODE {scpi}");
+
+            IoTimeout = deftimeout;
         }
 
         public void SendTrigger(int Channel)

--- a/OpenTap.Plugins.PNAX/Instrument/PNA.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNA.cs
@@ -114,10 +114,15 @@ namespace OpenTap.Plugins.PNAX
         [Display("Query for OPC", "Send OPC? after every command. Useful for debugging", Group: "Instrument Settings", Order: 4)]
         public bool IsWaitForOpc { get; set; }
 
-        [Display("Reference In", "", Group: "Reference", Order: 10)]
+        [Display("Enable Reference Oscillator Settings", Group: "Reference", Order: 10)]
+        public bool EnableReferenceOscillatorSettings { get; set; }
+
+        [EnabledIf("EnableReferenceOscillatorSettings", true, HideIfDisabled = true)]
+        [Display("Reference In", "Set the frequency reference of the instrument", Group: "Reference", Order: 11)]
         public VNAReferenceInEnumtype VNAReferenceIn { get; set; }
 
-        [Display("Reference Out", "", Group: "Reference", Order: 11)]
+        [EnabledIf("EnableReferenceOscillatorSettings", true, HideIfDisabled = true)]
+        [Display("Reference Out", "Set Reference out frequency", Group: "Reference", Order: 12)]
         public VNAReferenceFreqEnumtype VNAReferenceOut { get; set; }
 
         #endregion
@@ -149,6 +154,7 @@ namespace OpenTap.Plugins.PNAX
             IsQueryForErrors = true;
             IsWaitForOpc = true;
 
+            EnableReferenceOscillatorSettings = false;
             VNAReferenceIn = VNAReferenceInEnumtype.Internal;
             VNAReferenceOut = VNAReferenceFreqEnumtype.Ten;
         }
@@ -195,8 +201,11 @@ namespace OpenTap.Plugins.PNAX
                 Preset();
             }
 
-            SetReferenceIn(VNAReferenceIn);
-            SetVNAOutputReferenceOscillatorFrequency(VNAReferenceOut);
+            if (EnableReferenceOscillatorSettings)
+            {
+                SetReferenceIn(VNAReferenceIn);
+                SetVNAOutputReferenceOscillatorFrequency(VNAReferenceOut);
+            }
         }
 
         public void Preset()

--- a/OpenTap.Plugins.PNAX/Instrument/PNAConverters.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNAConverters.cs
@@ -99,6 +99,11 @@ namespace OpenTap.Plugins.PNAX
             ScpiCommand($"SENSe{ Channel }:MIXer:LO{ Stage }:NAME \"{str}\"");
         }
 
+        public void SetPortLO(int Channel, int Stage, string value)
+        {
+            ScpiCommand($"SENSe{ Channel }:MIXer:LO{ Stage }:NAME \"{value}\"");
+        }
+
         public bool GetEnableEmbeddedLO(int Channel)
         {
             return ScpiQuery<bool>($"SENS{ Channel }:MIXer:ELO:STATe?");
@@ -198,6 +203,11 @@ namespace OpenTap.Plugins.PNAX
             ScpiCommand($"SENS{ Channel }:MIXer:ELO:TUNing:IFBW { value }");
         }
 
+        public void SetTuningNoiseBW(int Channel, double value)
+        {
+            ScpiCommand($"SENSe{Channel}:MIXer:ELO:TUNing:NBW {value}");
+        }
+
         // PNA UI shows "Max Iterations" for this parameter
         public int GetTuningMaxIterations(int Channel)
         {
@@ -229,6 +239,11 @@ namespace OpenTap.Plugins.PNAX
         public void SetLOFrequencyDelta(int Channel, double value)
         {
             ScpiCommand($"SENS{ Channel }:MIXer:ELO:LO:DELTa { value }");
+        }
+
+        public void ResetLO(int Channel)
+        {
+            ScpiCommand($"SENS{ Channel }:MIXer:ELO:RESet");
         }
 
         #endregion
@@ -272,6 +287,12 @@ namespace OpenTap.Plugins.PNAX
             ScpiCommand($"SOURce{ Channel }:POWer{strPort}:ALC:MODE {mode}");
         }
 
+        public void SetSourceLevelingMode(int Channel, MODDutPortEnum port, string mode)
+        {
+            string strPort = Scpi.Format("{0}", port);
+            ScpiCommand($"SOURce{ Channel }:POWer:ALC:MODE {mode},\"{strPort}\"");
+        }
+
         public void SetSourceLevelingMode(int Channel, PortsEnum port, InputSourceLevelingModeEnum mode)
         {
             string strPort = Scpi.Format("{0}", port);
@@ -305,6 +326,12 @@ namespace OpenTap.Plugins.PNAX
         {
             string strPort = Scpi.Format("{0}", port);
             ScpiCommand($"SOURce{ Channel }:POWer{strPort}:ATTenuation { value }");
+        }
+
+        public void SetSourceAttenuator(int Channel, MODDutPortEnum port, double value)
+        {
+            string strPort = Scpi.Format("{0}", port);
+            ScpiCommand($"SOURce{ Channel }:POWer:ATTenuation { value },\"{strPort}\"");
         }
 
         public double GetReceiverAttenuator(int Channel, int port)

--- a/OpenTap.Plugins.PNAX/Instrument/PNAMath.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNAMath.cs
@@ -43,8 +43,84 @@ namespace OpenTap.Plugins.PNAX
         public double EndResp { get; set; }
     }
 
+    [Flags]
+    public enum MathStatisticTypeEnum
+    {
+        [Scpi("PTP")]
+        [Display("Peak to Peak")]
+        Ptp=1,
+        [Scpi("STDEV")]
+        [Display("Std Dev")]
+        Std=2,
+        [Scpi("MEAN")]
+        [Display("Mean")]
+        Mean=4,
+        [Scpi("MIN")]
+        [Display("Min")]
+        Min=8,
+        [Scpi("MAX")]
+        [Display("Max")]
+        Max=16
+    }
+
+    public enum MathStatisticsRangeEnum
+    {
+        [Scpi("0")]
+        [Display("Full Span")]
+        FullSpan,
+        [Scpi("1")]
+        [Display("User 1")]
+        User1,
+        [Scpi("2")]
+        [Display("User 2")]
+        User2,
+        [Scpi("3")]
+        [Display("User 3")]
+        User3,
+        [Scpi("4")]
+        [Display("User 4")]
+        User4,
+        [Scpi("5")]
+        [Display("User 5")]
+        User5,
+        [Scpi("6")]
+        [Display("User 6")]
+        User6,
+        [Scpi("7")]
+        [Display("User 7")]
+        User7,
+        [Scpi("8")]
+        [Display("User 8")]
+        User8,
+        [Scpi("9")]
+        [Display("User 9")]
+        User9,
+        [Scpi("10")]
+        [Display("User 10")]
+        User10,
+        [Scpi("11")]
+        [Display("User 11")]
+        User11,
+        [Scpi("12")]
+        [Display("User 12")]
+        User12,
+        [Scpi("13")]
+        [Display("User 13")]
+        User13,
+        [Scpi("14")]
+        [Display("User 14")]
+        User14,
+        [Scpi("15")]
+        [Display("User 15")]
+        User15,
+        [Scpi("16")]
+        [Display("User 16")]
+        User16,
+    }
+
     public partial class PNAX : ScpiInstrument
     {
+        #region Limits
         public void SetLimitTestOn(int Channel, int mnum, bool state)
         {
             string stateValue = state ? "ON" : "OFF";
@@ -116,5 +192,62 @@ namespace OpenTap.Plugins.PNAX
             string stateValue = state ? "ON" : "OFF";
             ScpiCommand($"DISP:FSIG {stateValue}");
         }
+        #endregion
+
+        #region Statistics
+        public void MathStatistics(int Channel, int mnum, bool state)
+        {
+            string stateValue = state ? "ON" : "OFF";
+            ScpiCommand($"CALCulate{Channel}:MEASure{mnum}:FUNCtion:STATistics:STATe {stateValue}");
+        }
+
+        public void MathType(int Channel, int mnum, MathStatisticTypeEnum mathStatisticType)
+        {
+            string StatisticType = Scpi.Format("{0}", mathStatisticType);
+            ScpiCommand($"CALCulate{Channel}:MEASure{mnum}:FUNCtion:TYPE {StatisticType}");
+        }
+
+        public void MathExecuteStatistics(int Channel, int mnum)
+        {
+            ScpiCommand($"CALCulate{Channel}:MEASure{mnum}:FUNCtion:EXECute");
+        }
+
+        public double MathData(int Channel, int mnum)
+        {
+            return ScpiQuery<double>($"CALCulate{Channel}:MEASure{mnum}:FUNCtion:DATA?");
+        }
+
+        public void MathShowResistance(int Channel, int mnum, bool state)
+        {
+            string stateValue = state ? "ON" : "OFF";
+            ScpiCommand($"CALCulate{Channel}:MEASure{mnum}:FUNCtion:STATistics:RESistance:STATe {stateValue}");
+        }
+
+        public void MathStatisticsRange(int Channel, int mnum, MathStatisticsRangeEnum mathStatisticsRange)
+        {
+            string StatisticRange = Scpi.Format("{0}", mathStatisticsRange);
+            ScpiCommand($"CALCulate{Channel}:MEASure{mnum}:FUNCtion:DOMain:USER:RANGe {StatisticRange}");
+        }
+
+        public void MathStatisticsRangeStart(int Channel, int mnum, MathStatisticsRangeEnum mathStatisticsRange, double value)
+        {
+            if (mathStatisticsRange == MathStatisticsRangeEnum.FullSpan)
+            {
+                throw new Exception("Full span can't set start/stop");
+            }
+            string StatisticRange = Scpi.Format("{0}", mathStatisticsRange);
+            ScpiCommand($"CALCulate{Channel}:MEASure{mnum}:FUNCtion:DOMain:USER:STARt {StatisticRange}, {value}");
+        }
+
+        public void MathStatisticsRangeStop(int Channel, int mnum, MathStatisticsRangeEnum mathStatisticsRange, double value)
+        {
+            if (mathStatisticsRange == MathStatisticsRangeEnum.FullSpan)
+            {
+                throw new Exception("Full span can't set start/stop");
+            }
+            string StatisticRange = Scpi.Format("{0}", mathStatisticsRange);
+            ScpiCommand($"CALCulate{Channel}:MEASure{mnum}:FUNCtion:DOMain:USER:STOP {StatisticRange}, {value}");
+        }
+        #endregion
     }
 }

--- a/OpenTap.Plugins.PNAX/Instrument/PNAModulationDistortion.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNAModulationDistortion.cs
@@ -609,6 +609,11 @@ namespace OpenTap.Plugins.PNAX
             string InstrumentFileName = "";
             string InstrumentFolderName = "";
 
+            if (GetDriveAccess() == false)
+            {
+                throw new Exception("Make Sure to Enable Remote Drive Access on the VNA.\nGo to Instrument | Setup | System Setup | Remote Interface… and Enable Remote Drive Access");
+            }
+
             InstrumentFileName = @"C:\Users\Public\Documents\Network Analyzer\" + FileName;
             InstrumentFolderName = @"C:\Users\Public\Documents\Network Analyzer\";
 

--- a/OpenTap.Plugins.PNAX/Instrument/PNAModulationDistortion.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNAModulationDistortion.cs
@@ -342,6 +342,17 @@ namespace OpenTap.Plugins.PNAX
         List
     }
 
+    public enum MODDutPortEnum
+    {
+        [Scpi("Port 1")]
+        Port1 = 1,
+        [Scpi("Port 2")]
+        Port2 = 2,
+        [Scpi("Port 3")]
+        Port3 = 3,
+        [Scpi("Port 4")]
+        Port4 = 4
+    }
 
     public partial class PNAX : ScpiInstrument
     {
@@ -415,6 +426,69 @@ namespace OpenTap.Plugins.PNAX
         }
 
         #endregion
+
+        #region RF Path
+        public void MODSourceAttenuatorInclude(int Channel, bool state)
+        {
+            String StateStr = "OFF";
+            if (state)
+            {
+                StateStr = "ON";
+            }
+            ScpiCommand($"SENSe{Channel}:DISTortion:PATH:SOURce:ATTenuation:INCLude {StateStr}");
+        }
+
+        public void MODSourceAttenuator(int Channel, double value, MODDutPortEnum source)
+        {
+            string dutport = Scpi.Format("{0}", source);
+            ScpiCommand($"SOURce{Channel}:POWer:ATTenuation {value}, \"{dutport}\"");
+        }
+
+        public void MODNominalSource(int Channel, double value)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:PATH:SOURce:NOMinal:AMPLifier {value}");
+        }
+
+        public void MODDutInput(int Channel, MODDutPortEnum dutinput)
+        {
+            int port = (int)dutinput;
+            ScpiCommand($"SENSe{Channel}:DISTortion:PATH:DUT:INPut {port}");
+        }
+
+        public void MODNominalDUTGain(int Channel, double value)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:PATH:DUT:NOMinal:GAIN {value}");
+        }
+
+        public void MODDutOutput(int Channel, MODDutPortEnum dutoutput)
+        {
+            int port = (int)dutoutput;
+            ScpiCommand($"SENSe{Channel}:DISTortion:PATH:DUT:OUTPut {port}");
+        }
+
+        public void MODReceiverAttenuator(int Channel, double value, MODDutPortEnum dutport)
+        {
+            int port = (int)dutport;
+            ScpiCommand($"SOURce{Channel}:POWer{port}:ATTenuation:RECeiver:TEST {value}");
+        }
+        
+        public void MODNominalDUTNFInclude(int Channel, bool state)
+        {
+            String StateStr = "OFF";
+            if (state)
+            {
+                StateStr = "ON";
+            }
+            ScpiCommand($"SENSe{Channel}:DISTortion:PATH:DUT:NOMinal:NF:INCLude {StateStr}");
+        }
+
+        public void MODNominalDUTNF(int Channel, double value)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:PATH:DUT:NOMinal:NF {value}");
+        }
+
+        #endregion
+
 
         public void SetMODSource(int Channel, String source)
         {

--- a/OpenTap.Plugins.PNAX/Instrument/PNAModulationDistortion.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNAModulationDistortion.cs
@@ -316,8 +316,106 @@ namespace OpenTap.Plugins.PNAX
         RRC
     }
 
+    public enum MODSweepTypeEnum
+    {
+        [Scpi("FIX")]
+        Fixed,
+        [Scpi("POW")]
+        Power
+    }
+
+    public enum MODPowerPortEnum
+    {
+        [Scpi("DIN1")]
+        [Display("DUT input")]
+        Din,
+        [Scpi("DOUT2")]
+        [Display("DUT output")]
+        Dout
+    }
+
+    public enum MODSweepPowerTypeEnum
+    {
+        [Scpi("RAMP")]
+        Ramp,
+        [Scpi("LIST")]
+        List
+    }
+
+
     public partial class PNAX : ScpiInstrument
     {
+        #region Sweep
+        public void MODSweepType(int Channel, MODSweepTypeEnum swepTypeEnum)
+        {
+            string SweepType = Scpi.Format("{0}", swepTypeEnum);
+            ScpiCommand($"SENSe{Channel}:DISTortion:SWEep:TYPE {SweepType}");
+        }
+
+        public void MODCarrierFreq(int Channel, double value)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:SWEep:CARRier:FREQuency {value}");
+        }
+
+        public void MODSpan(int Channel, double value)
+        {
+            ScpiCommand($"SENSe{Channel}:FREQuency:SPAN {value}");
+        }
+
+        public void MODNoiseBW(int Channel, double value)
+        {
+            ScpiCommand($"SENSe{Channel}:SA:BANDwidth:NOISe {value}");
+        }
+
+        public void MODSetPowerPort(int Channel, MODPowerPortEnum powerPort)
+        {
+            string MODPowerPort = Scpi.Format("{0}", powerPort);
+            ScpiCommand($"SENSe{Channel}:DISTortion:SWEep:POWer:CARRier:LEVel:PORT {MODPowerPort}");
+        }
+
+        public void MODSetPower(int Channel, double value)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:SWEep:POWer:CARRier:LEVel {value}");
+        }
+
+        public void MODPowerSweepType(int Channel, MODSweepPowerTypeEnum powerType, int index = 1)
+        {
+            string MODPowerType = Scpi.Format("{0}", powerType);
+            ScpiCommand($"SENSe{Channel}:DISTortion:SWEep:POWer:CARRier:LEVel{index}:TYPE {MODPowerType}");
+        }
+
+        public void MODPowerSweepStart(int Channel, double value, int index = 1)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:SWEep:POWer:CARRier:RAMP:LEVel{index}:STARt {value}");
+        }
+
+        public void MODPowerSweepStop(int Channel, double value, int index = 1)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:SWEep:POWer:CARRier:RAMP:LEVel{index}:STOP {value}");
+        }
+
+        public void MODPowerSweepNumberOfPoints(int Channel, int value)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:SWEep:POWer:CARRier:RAMP:POINts {value}");
+        }
+
+        public void MODPowerSweepNoiseBW(int Channel, int value, int index = 1)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:SWEep:POWer:CARRier:LIST{index}:NBW {value}");
+        }
+
+        public void MODPowerSweepAutoIncreaseBW(int Channel, bool state)
+        {
+            String StateStr = "OFF";
+            if (state)
+            {
+                StateStr = "ON";
+            }
+            ScpiCommand($"SENSe{Channel}:DISTortion:SWEep:POWer:CARRier:RAMP:NBW:AUTO {StateStr}");
+        }
+
+        #endregion
+
         public void SetMODSource(int Channel, String source)
         {
             ScpiCommand($"SENSe{Channel}:DISTortion:MODulate:SOURce \"{source}\"");
@@ -396,7 +494,18 @@ namespace OpenTap.Plugins.PNAX
 
         public string MODGetCalibrationDetails(int Channel, string port)
         {
-            return ScpiQuery($"SOURce{Channel}:MODulation:CORRection:COLLection:ACQuire:DETails? \"{port}\"");
+            // Calibration details returns multiple single responses, using SCPIQuery leaves multiple lines on the queue
+            // Better not to use Calibration Details for now
+
+            String retString = "";
+            //String line = "";
+            //retString = ScpiQuery($"SOURce{Channel}:MODulation:CORRection:COLLection:ACQuire:DETails? \"{port}\"");
+            //do
+            //{
+            //    line = ScpiQuery($"");
+            //    retString += line;
+            //} while (!line.Equals("\""));
+            return retString;
         }
 
         public void MODSaveDistortionTable(int Channel, string FullFileName)

--- a/OpenTap.Plugins.PNAX/Instrument/PNAModulationDistortion.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNAModulationDistortion.cs
@@ -298,8 +298,23 @@ namespace OpenTap.Plugins.PNAX
         ACPAvgDist21dBc = 64
     }
 
-    
+    public enum MODAntialiasFilterEnum
+    {
+        [Scpi("NARR")]
+        Narrow,
+        [Scpi("WIDE")]
+        Wide,
+        [Scpi("AUTO")]
+        Auto
+    }
 
+    public enum MODFilterEnum
+    {
+        [Scpi("NONE")]
+        None,
+        [Scpi("RRC")]
+        RRC
+    }
 
     public partial class PNAX : ScpiInstrument
     {
@@ -521,6 +536,63 @@ namespace OpenTap.Plugins.PNAX
                 StateStr = "DISTortion";
             }
             ScpiCommand($"DISPlay:WINDow{wnum}:TABLe {StateStr}");
+        }
+
+        public void MODCorrelationAperture(int Channel, double value)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:MEASure:CORRelation:APERture {value}");
+        }
+
+        public void MODCorrelationApertureAuto(int Channel, bool state)
+        {
+            String StateStr = "OFF";
+            if (state)
+            {
+                StateStr = "ON";
+            }
+            ScpiCommand($"SENSe{Channel}:DISTortion:MEASure:CORRelation:APERture:AUTO:STATe {StateStr}");
+        }
+
+        public void MODAntialiasFilter(int Channel, MODAntialiasFilterEnum antialiasFilter)
+        {
+            string modAntialiasFilter = Scpi.Format("{0}", antialiasFilter);
+            ScpiCommand($"SENSe{Channel}:DISTortion:ADC:FILTer:TYPE {modAntialiasFilter}");
+        }
+
+        public void MODEVMNormalization(int Channel, double value)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:EVM:NORMalize {value}");
+        }
+
+        public void MODDutNF(int Channel, double value)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:PATH:DUT:NOMinal:NF {value}");
+        }
+
+        public void MODFilter(int Channel, MODFilterEnum filter)
+        {
+            string Filter = Scpi.Format("{0}", filter);
+            ScpiCommand($"SENSe{Channel}:DISTortion:MEASure:FILTer {Filter}");
+        }
+
+        public void MODFilterAlpha(int Channel, int alpha)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:MEASure:FILTer:ALPHa {alpha}");
+        }
+
+        public void MODFilterSymbolRate(int Channel, double srate)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:MEASure:FILTer:SRATe {srate}");
+        }
+
+        public void MODFilterSymbolRateAuto(int Channel, bool state)
+        {
+            String StateStr = "OFF";
+            if (state)
+            {
+                StateStr = "ON";
+            }
+            ScpiCommand($"SENSe{Channel}:DISTortion:MEASure:FILTer:SRATe:AUTO:STATe {StateStr}");
         }
     }
 }

--- a/OpenTap.Plugins.PNAX/Instrument/PNAModulationDistortion.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNAModulationDistortion.cs
@@ -15,6 +15,7 @@ using System.Text;
 
 namespace OpenTap.Plugins.PNAX
 {
+    #region enums
     static class EnumExtensions
     {
         public static List<string> MODGetFlags(this Enum flags)
@@ -353,6 +354,7 @@ namespace OpenTap.Plugins.PNAX
         [Scpi("Port 4")]
         Port4 = 4
     }
+    #endregion
 
     public partial class PNAX : ScpiInstrument
     {
@@ -489,7 +491,7 @@ namespace OpenTap.Plugins.PNAX
 
         #endregion
 
-
+        #region Modulate and Measure
         public void SetMODSource(int Channel, String source)
         {
             ScpiCommand($"SENSe{Channel}:DISTortion:MODulate:SOURce \"{source}\"");
@@ -777,5 +779,14 @@ namespace OpenTap.Plugins.PNAX
             }
             ScpiCommand($"SENSe{Channel}:DISTortion:MEASure:FILTer:SRATe:AUTO:STATe {StateStr}");
         }
+
+        #endregion
+
+        #region Mixers
+        public void MODMixerSourceRole(int Channel, string role, string source)
+        {
+            ScpiCommand($"SENSe{Channel}:ROLE:DEVice \"{role}\",\"{source}\"");
+        }
+        #endregion
     }
 }

--- a/OpenTap.Plugins.PNAX/Instrument/PNAModulationDistortion.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNAModulationDistortion.cs
@@ -18,7 +18,7 @@ namespace OpenTap.Plugins.PNAX
     #region enums
     static class EnumExtensions
     {
-        public static List<string> MODGetFlags(this Enum flags)
+        public static List<string> MODGetFlagsScpi(this Enum flags)
         {
             List<string> retString = new List<string>();
             foreach (var value in Enum.GetValues(flags.GetType()).Cast<Enum>())
@@ -30,6 +30,24 @@ namespace OpenTap.Plugins.PNAX
                 if ((bits & mask) == bits)
                 {
                     string paramName = Scpi.Format("{0}", value);
+                    retString.Add(paramName);
+                }
+            }
+            return retString;
+        }
+
+        public static List<string> MODGetFlagsDisplay(this Enum flags)
+        {
+            List<string> retString = new List<string>();
+            foreach (var value in Enum.GetValues(flags.GetType()).Cast<Enum>())
+            {
+                ulong mask = Convert.ToUInt64(flags);
+                ulong bits = Convert.ToUInt64(value);
+                if (bits == 0L)
+                    continue; // skip the zero value
+                if ((bits & mask) == bits)
+                {
+                    string paramName = value.ToString();
                     retString.Add(paramName);
                 }
             }
@@ -660,7 +678,7 @@ namespace OpenTap.Plugins.PNAX
         
         public void MODTableAddParameter(int Channel, MODTableSetupCarrierEnum modParamName)
         {
-            List<string> paramNames = modParamName.MODGetFlags();
+            List<string> paramNames = modParamName.MODGetFlagsScpi();
 
             foreach (string paramName in paramNames)
             {
@@ -670,7 +688,7 @@ namespace OpenTap.Plugins.PNAX
 
         public void MODTableAddParameter(int Channel, MODTableSetupEVMEnum modParamName)
         {
-            List<string> paramNames = modParamName.MODGetFlags();
+            List<string> paramNames = modParamName.MODGetFlagsScpi();
 
             foreach (string paramName in paramNames)
             {
@@ -680,7 +698,7 @@ namespace OpenTap.Plugins.PNAX
 
         public void MODTableAddParameter(int Channel, MODTableSetupNPREnum modParamName)
         {
-            List<string> paramNames = modParamName.MODGetFlags();
+            List<string> paramNames = modParamName.MODGetFlagsScpi();
 
             foreach (string paramName in paramNames)
             {
@@ -690,7 +708,7 @@ namespace OpenTap.Plugins.PNAX
 
         public void MODTableAddParameter(int Channel, MODTableSetupACPEnum modParamName)
         {
-            List<string> paramNames = modParamName.MODGetFlags();
+            List<string> paramNames = modParamName.MODGetFlagsScpi();
 
             foreach (string paramName in paramNames)
             {
@@ -700,7 +718,7 @@ namespace OpenTap.Plugins.PNAX
 
         public void MODTableAddParameter(int Channel, MODTableSetupACPAvgEnum modParamName)
         {
-            List<string> paramNames = modParamName.MODGetFlags();
+            List<string> paramNames = modParamName.MODGetFlagsScpi();
 
             foreach (string paramName in paramNames)
             {

--- a/OpenTap.Plugins.PNAX/Instrument/PNAModulationDistortion.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNAModulationDistortion.cs
@@ -1,0 +1,498 @@
+﻿using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.Remoting.Channels;
+using System.Text;
+
+//Note this template assumes that you have a SCPI based instrument, and accordingly
+//extends the ScpiInstrument base class.
+
+//If you do NOT have a SCPI based instrument, you should modify this instance to extend
+//the (less powerful) Instrument base class.
+
+namespace OpenTap.Plugins.PNAX
+{
+    static class EnumExtensions
+    {
+        public static List<string> MODGetFlags(this Enum flags)
+        {
+            List<string> retString = new List<string>();
+            foreach (var value in Enum.GetValues(flags.GetType()).Cast<Enum>())
+            {
+                ulong mask = Convert.ToUInt64(flags);
+                ulong bits = Convert.ToUInt64(value);
+                if (bits == 0L)
+                    continue; // skip the zero value
+                if ((bits & mask) == bits)
+                {
+                    string paramName = Scpi.Format("{0}", value);
+                    retString.Add(paramName);
+                }
+            }
+            return retString;
+        }
+    }
+
+    public enum MODSourceCorrectionEnum
+    {
+        [Display("Off")]
+        [Scpi("OFF")]
+        OFF,
+        [Display("Modulation")]
+        [Scpi("MODulation")]
+        MODulation,
+        [Display("Power")]
+        [Scpi("POWer")]
+        POWer,
+        [Display("Mod & Pwr")]
+        [Scpi("MODPwr")]
+        MODPwr
+    }
+
+    public enum MODCalPortEnum
+    {
+        DUTIn1,
+        DUTOut2,
+        DUTOut3,
+        DUTOut4,
+        DUTOut5
+    }
+
+    public enum MODCalTypeEnum
+    {
+        [Scpi("POWer")]
+        POWer,
+        [Scpi("EQUalization")]
+        EQUalization,
+        [Scpi("LO:FTHRu")]
+        LO,
+        [Scpi("DISTortion")]
+        DISTortion,
+        [Scpi("NOTch")]
+        NOTch,
+        [Scpi("ACP:LOWer")]
+        ACPLower,
+        [Scpi("ACP:UPPer")]
+        ACPUpper
+    }
+
+    public enum MODCalSynchTypeEnum
+    {
+        [Display("Synchronous")]
+        [Scpi("SYNC")]
+        SYNChronous,
+        [Display("Asynchrounous")]
+        [Scpi("ASYN")]
+        ASYNchrounous
+    }
+
+    public enum MODMeasurementTypeEnum
+    {
+        [Scpi("ACP")]
+        [Display("ACP")]
+        ACP,
+        [Scpi("ACPEVM")]
+        [Display("ACP+EVM")]
+        ACPEVM,
+        [Scpi("BPWR")]
+        [Display("Band Power")]
+        BPWR,
+        [Scpi("EVM")]
+        [Display("EVM")]
+        EVM,
+        [Scpi("NPR")]
+        [Display("NPR")]
+        NPR
+    }
+
+    public enum MODMeasConfigTypeEnum
+    {
+        [Scpi("CARRier")]
+        CARRier,
+        [Scpi("ACP:LOWer")]
+        ACPLower,
+        [Scpi("ACP:UPPer")]
+        ACPUpper,
+        [Scpi("NOTCh")]
+        Notch
+    }
+
+    [Flags]
+    public enum MODTableSetupCarrierEnum
+    {
+        [Display("Carrier In1 dBm")]
+        [Scpi("Carrier In1 dBm")]
+        CarrierIn1dBm = 1,
+        [Display("Carrier In1 dBm/Hz")]
+        [Scpi("Carrier In1 dBm/Hz")]
+        CarrierIn1dBmHz = 2,
+        [Display("Carrier PDlvrIn1 dBm")]
+        [Scpi("Carrier PDlvrIn1 dBm")]
+        CarrierPDlvrIn1dBm = 4,
+        [Display("Carrier PDlvrIn1 dBm/Hz")]
+        [Scpi("Carrier PDlvrIn1 dBm/Hz")]
+        CarrierPDlvrIn1dBmHz = 8,
+        [Display("Carrier Out2 dBm")]
+        [Scpi("Carrier Out2 dBm")]
+        CarrierOut2dBm = 16,
+        [Display("Carrier Out2 dBm/Hz")]
+        [Scpi("Carrier Out2 dBm/Hz")]
+        CarrierOut2dBmHz = 32,
+        [Display("Carrier PDlvrOut2 dBm")]
+        [Scpi("Carrier PDlvrOut2 dBm")]
+        CarrierPDlvrOut2dBm = 64,
+        [Display("Carrier PDlvrOut2 dBm/Hz")]
+        [Scpi("Carrier PDlvrOut2 dBm/Hz")]
+        CarrierPDlvrOut2dBmHz = 128,
+        [Display("Carrier Gain21 dB")]
+        [Scpi("Carrier Gain21 dB")]
+        CarrierGain21dB = 256,
+        [Display("Carrier IBW")]
+        [Scpi("Carrier IBW")]
+        CarrierIBW = 512,
+        [Display("Carrier OffsFreq")]
+        [Scpi("Carrier OffsFreq")]
+        CarrierOffsFreq = 1024,
+        [Display("Carrier Filter")]
+        [Scpi("Carrier Filter")]
+        CarrierFilter = 2048
+    }
+
+    [Flags]
+    public enum MODTableSetupEVMEnum
+    {
+        [Display("EVM DistEq21 dBc")]
+        [Scpi("EVM DistEq21 dBc")]
+        EVMDistEq21dBc = 1,
+        [Display("EVM DistEq21 %")]
+        [Scpi("EVM DistEq21 %")]
+        EVMDistEq21 = 2,
+        [Display("EVM DistUn21 dBc")]
+        [Scpi("EVM DistUn21 dBc")]
+        EVMDistUn21dBc = 4,
+        [Display("EVM DistUn21 %")]
+        [Scpi("EVM DistUn21 %")]
+        EVMDistUn21 = 8,
+        [Display("EVM Norm")]
+        [Scpi("EVM Norm")]
+        EVMNorm = 16
+    }
+
+    [Flags]
+    public enum MODTableSetupNPREnum
+    {
+        [Display("NPR In1 dBc")]
+        [Scpi("NPR In1 dBc")]
+        NPRIn1dBc = 1,
+        [Display("NPR In1 dBm")]
+        [Scpi("NPR In1 dBm")]
+        NPRIn1dBm = 2,
+        [Display("NPR In1 dBm/Hz")]
+        [Scpi("NPR In1 dBm/Hz")]
+        NPRIn1dBmHz = 4,
+        [Display("NPR Out2 dBc")]
+        [Scpi("NPR Out2 dBc")]
+        NPROut2dBc = 8,
+        [Display("NPR Out2 dBm")]
+        [Scpi("NPR Out2 dBm")]
+        NPROut2dBm = 16,
+        [Display("NPR Out2 dBm/Hz")]
+        [Scpi("NPR Out2 dBm/Hz")]
+        NPROut2dBmHz = 32,
+        [Display("NPR Dist21 dBc")]
+        [Scpi("NPR Dist21 dBc")]
+        NPRDist21dBc = 64,
+        [Display("NPR NtchIBW")]
+        [Scpi("NPR NtchIBW")]
+        NPRNtchIBW = 128,
+        [Display("NPR NtchOffsFreq")]
+        [Scpi("NPR NtchOffsFreq")]
+        NPRNtchOffsFreq = 256
+    }
+
+    [Flags]
+    public enum MODTableSetupACPEnum
+    {
+        [Display("ACP LoIn1 dBc")]
+        [Scpi("ACP LoIn1 dBc")]
+        ACPLoIn1dBc = 1,
+        [Display("ACP LoIn1 dBm")]
+        [Scpi("ACP LoIn1 dBm")]
+        ACPLoIn1dBm = 2,
+        [Display("ACP LoIn1 dBm/Hz")]
+        [Scpi("ACP LoIn1 dBm/Hz")]
+        ACPLoIn1dBmHz = 4,
+        [Display("ACP LoOut2 dBc")]
+        [Scpi("ACP LoOut2 dBc")]
+        ACPLoOut2dBc = 8,
+        [Display("ACP LoOut2 dBm")]
+        [Scpi("ACP LoOut2 dBm")]
+        ACPLoOut2dBm = 16,
+        [Display("ACP LoOut2 dBm/Hz")]
+        [Scpi("ACP LoOut2 dBm/Hz")]
+        ACPLoOut2dBmHz = 32,
+        [Display("ACP LoDist21 dBc")]
+        [Scpi("ACP LoDist21 dBc")]
+        ACPLoDist21dBc = 64,
+        [Display("ACP LoIBW")]
+        [Scpi("ACP LoIBW")]
+        ACPLoIBW = 128,
+        [Display("ACP LoOffsFreq")]
+        [Scpi("ACP LoOffsFreq")]
+        ACPLoOffsFreq = 256,
+        [Display("ACP UpIn1 dBc")]
+        [Scpi("ACP UpIn1 dBc")]
+        ACPUpIn1dBc = 512,
+        [Display("ACP UpIn1 dBm")]
+        [Scpi("ACP UpIn1 dBm")]
+        ACPUpIn1dBm = 1024,
+        [Display("ACP UpIn1 dBm/Hz")]
+        [Scpi("ACP UpIn1 dBm/Hz")]
+        ACPUpIn1dBmHz = 2048,
+        [Display("ACP UpOut2 dBc")]
+        [Scpi("ACP UpOut2 dBc")]
+        ACPUpOut2dBc = 4096,
+        [Display("ACP UpOut2 dBm")]
+        [Scpi("ACP UpOut2 dBm")]
+        ACPUpOut2dBm = 8192,
+        [Display("ACP UpOut2 dBm/Hz")]
+        [Scpi("ACP UpOut2 dBm/Hz")]
+        ACPUpOut2dBmHz = 16384,
+        [Display("ACP UpDist21 dBc")]
+        [Scpi("ACP UpDist21 dBc")]
+        ACPUpDist21dBc = 32768,
+        [Display("ACP UpIBW")]
+        [Scpi("ACP UpIBW")]
+        ACPUpIBW = 65536,
+        [Display("ACP UpOffsFreq")]
+        [Scpi("ACP UpOffsFreq")]
+        ACPUpOffsFreq = 131072
+    }
+
+    [Flags]
+    public enum MODTableSetupACPAvgEnum
+    {
+        [Display("ACP AvgIn1 dBc")]
+        [Scpi("ACP AvgIn1 dBc")]
+        ACPAvgIn1dBc = 1,
+        [Display("ACP AvgIn1 dBm")]
+        [Scpi("ACP AvgIn1 dBm")]
+        ACPAvgIn1dBm = 2,
+        [Display("ACP AvgIn1 dBm/Hz")]
+        [Scpi("ACP AvgIn1 dBm/Hz")]
+        ACPAvgIn1dBmHz = 4,
+        [Display("ACP AvgOut2 dBc")]
+        [Scpi("ACP AvgOut2 dBc")]
+        ACPAvgOut2dBc = 8,
+        [Display("ACP AvgOut2 dBm")]
+        [Scpi("ACP AvgOut2 dBm")]
+        ACPAvgOut2dBm = 16,
+        [Display("ACP AvgOut2 dBm/Hz")]
+        [Scpi("ACP AvgOut2 dBm/Hz")]
+        ACPAvgOut2dBmHz = 32,
+        [Display("ACP AvgDist21 dBc")]
+        [Scpi("ACP AvgDist21 dBc")]
+        ACPAvgDist21dBc = 64
+    }
+
+    
+
+
+    public partial class PNAX : ScpiInstrument
+    {
+        public void SetMODSource(int Channel, String source)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:MODulate:SOURce \"{source}\"");
+        }
+
+        public void MODLoadFile(int Channel, string port, string filename)
+        {
+            //ScpiCommand($"SOURce{Channel}:MODulation:FILE:LOAD \"{filename}\",\"{port}\"");
+            ScpiCommand($"SOURce{Channel}:MODulation:LOAD \"{filename}\",\"{port}\"");
+        }
+
+        public void MODEnableModulation(int Channel, string port, bool state)
+        {
+            String StateStr = "OFF";
+            if (state)
+            {
+                StateStr = "ON";
+            }
+            ScpiCommand($"SOURce{Channel}:MODulation:STATe {StateStr}, \"{port}\"");
+        }
+
+        public void MODSourceCorrection(int Channel, string port, MODSourceCorrectionEnum sourceCorrectionType)
+        {
+            string sourceCorrection = Scpi.Format("{0}", sourceCorrectionType);
+
+            ScpiCommand($"SOURce{Channel}:CORRection:SELect {sourceCorrection},\"{port}\"");
+        }
+
+        public void MODCalEnable(int Channel, string port, bool state, MODCalTypeEnum MODCalType)
+        {
+            String StateStr = "OFF";
+            if (state)
+            {
+                StateStr = "ON";
+            }
+            string calType = Scpi.Format("{0}", MODCalType);
+            ScpiCommand($"SOURce{Channel}:MODulation:CORRection:COLLection:{calType}:ENABle {StateStr}, \"{port}\"");
+        }
+
+        public void MODCalPort(int Channel, string port, MODCalPortEnum MODCalPort, MODCalTypeEnum MODCalType)
+        {
+            string calType = Scpi.Format("{0}", MODCalType);
+            string calPort = Scpi.Format("{0}", MODCalPort);
+            ScpiCommand($"SOURce{Channel}:MODulation:CORRection:COLLection:{calType}:RECeiver \"{calPort}\", \"{port}\"");
+        }
+
+        public void MODCalSpan(int Channel, string port, double CalSpan, MODCalTypeEnum MODCalType)
+        {
+            string calType = Scpi.Format("{0}", MODCalType);
+            ScpiCommand($"SOURce{Channel}:MODulation:CORRection:COLLection:{calType}:SPAN {CalSpan}, \"{port}\"");
+        }
+
+        public void MODCalGuardBand(int Channel, string port, double GuardBand, MODCalTypeEnum MODCalType)
+        {
+            string calType = Scpi.Format("{0}", MODCalType);
+            ScpiCommand($"SOURce{Channel}:MODulation:CORRection:COLLection:{calType}:GBANd {GuardBand}, \"{port}\"");
+        }
+
+        public void MODCalMaxIterations(int Channel, string port, int MaxIterations, MODCalTypeEnum MODCalType)
+        {
+            string calType = Scpi.Format("{0}", MODCalType);
+            ScpiCommand($"SOURce{Channel}:MODulation:CORRection:COLLection:{calType}:ITERations {MaxIterations}, \"{port}\"");
+        }
+
+        public void MODCalDesiredTolearance(int Channel, string port, double DesiredTolerance, MODCalTypeEnum MODCalType)
+        {
+            string calType = Scpi.Format("{0}", MODCalType);
+            ScpiCommand($"SOURce{Channel}:MODulation:CORRection:COLLection:{calType}:TOLerance {DesiredTolerance}, \"{port}\"");
+        }
+
+        public void MODCalibrationMeasure(int Channel, string port, MODCalSynchTypeEnum CalSynchType = MODCalSynchTypeEnum.SYNChronous)
+        {
+            string synchType = Scpi.Format("{0}", CalSynchType);
+            ScpiCommand($"SOURce{Channel}:MODulation:CORRection:COLLection:ACQuire {synchType}, \"{port}\"", 60000);
+        }
+
+        public string MODGetCalibrationDetails(int Channel, string port)
+        {
+            return ScpiQuery($"SOURce{Channel}:MODulation:CORRection:COLLection:ACQuire:DETails? \"{port}\"");
+        }
+
+        public void MODSaveDistortionTable(int Channel, string filename)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:TABLe:DISPlay:SAVE \"{filename}\"");
+        }
+
+        public string MODGetCalibrationStatus(int Channel, string port)
+        {
+            return ScpiQuery($"SOURce{Channel}:MODulation:CORRection:COLLection:ACQuire:STATus? \"{port}\"");
+        }
+
+        public void MODSetMeasType(int Channel, MODMeasurementTypeEnum measType, int bnum = 1)
+        {
+            string modMeasType = Scpi.Format("{0}", measType);
+            ScpiCommand($"SENSe{Channel}:DISTortion:MEASure:BAND{bnum}:TYPE {modMeasType}");
+        }
+
+        public void MODSetIBW(int Channel, double ibw, MODMeasConfigTypeEnum measConfType, int bnum = 1)
+        {
+            string MeasConf = Scpi.Format("{0}", measConfType);
+            ScpiCommand($"SENSe{Channel}:DISTortion:MEASure:BAND{bnum}:{MeasConf}:IBW {ibw}");
+        }
+
+        public void MODSetOffset(int Channel, double offset, MODMeasConfigTypeEnum measConfType, int bnum = 1)
+        {
+            string MeasConf = Scpi.Format("{0}", measConfType);
+            ScpiCommand($"SENSe{Channel}:DISTortion:MEASure:BAND{bnum}:{MeasConf}:OFFSet {offset}");
+        }
+
+        public void MODAutofill(int Channel, int bnum = 1)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:MEASure:BAND{bnum}:AUTofill");
+        }
+
+        public double MODGetDataValue(int Channel, string paramName, int bnum = 1)
+        {
+            return ScpiQuery<double>($"SENSe{Channel}:DISTortion:TABLe:DATA:VALue? {bnum},\"{paramName}\"");
+        }
+
+        public List<string> MODGetAllColumnNames(int Channel)
+        {
+            string retString = ScpiQuery($"SENSe{Channel}:DISTortion:TABLe:DISPlay:CATalog?");
+            retString = retString.Replace("\"", "");
+            List<string> retVal = retString.Split(',').ToList<string>();
+            return retVal;
+        }
+
+        
+        public void MODTableAddParameter(int Channel, MODTableSetupCarrierEnum modParamName)
+        {
+            List<string> paramNames = modParamName.MODGetFlags();
+
+            foreach (string paramName in paramNames)
+            {
+                MODTableAddParameter(Channel, paramName);
+            }
+        }
+
+        public void MODTableAddParameter(int Channel, MODTableSetupEVMEnum modParamName)
+        {
+            List<string> paramNames = modParamName.MODGetFlags();
+
+            foreach (string paramName in paramNames)
+            {
+                MODTableAddParameter(Channel, paramName);
+            }
+        }
+
+        public void MODTableAddParameter(int Channel, MODTableSetupNPREnum modParamName)
+        {
+            List<string> paramNames = modParamName.MODGetFlags();
+
+            foreach (string paramName in paramNames)
+            {
+                MODTableAddParameter(Channel, paramName);
+            }
+        }
+
+        public void MODTableAddParameter(int Channel, MODTableSetupACPEnum modParamName)
+        {
+            List<string> paramNames = modParamName.MODGetFlags();
+
+            foreach (string paramName in paramNames)
+            {
+                MODTableAddParameter(Channel, paramName);
+            }
+        }
+
+        public void MODTableAddParameter(int Channel, MODTableSetupACPAvgEnum modParamName)
+        {
+            List<string> paramNames = modParamName.MODGetFlags();
+
+            foreach (string paramName in paramNames)
+            {
+                MODTableAddParameter(Channel, paramName);
+            }
+        }
+
+        public void MODTableAddParameter(int Channel, string paramName)
+        {
+            ScpiCommand($"SENSe{Channel}:DISTortion:TABLe:DISPlay:FEED \"{paramName}\"");
+        }
+
+        public void MODShowTable(int wnum, bool state)
+        {
+            String StateStr = "OFF";
+            if (state)
+            {
+                StateStr = "DISTortion";
+            }
+            ScpiCommand($"DISPlay:WINDow{wnum}:TABLe {StateStr}");
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/LMS/Measure.cs
+++ b/OpenTap.Plugins.PNAX/LMS/Measure.cs
@@ -23,11 +23,15 @@ namespace OpenTap.Plugins.PNAX
         [Display("Channels", Description: "Choose which channels to trigger.", "Measurements")]
         public List<int> channels { get; set; }
         // ToDo: Add property here for each parameter the end user should be able to change
+
+        [Display("Sweep Mode", Group: "Settings", Order: 10)]
+        public SweepModeEnumType sweepMode { get; set; }
         #endregion
 
         public Measure()
         {
             channels = new List<int> { };
+            sweepMode = SweepModeEnumType.SING;
             // ToDo: Set default values for properties / settings.
         }
 
@@ -37,7 +41,13 @@ namespace OpenTap.Plugins.PNAX
 
             try
             {
-                PNAX.MeasureState(channels);
+                List<int> activeChannels = PNAX.GetActiveChannels();
+                channels = PNAX.ChannelListCheck(channels, activeChannels);
+                // Trigger every channel
+                foreach (var channel in channels)
+                {
+                    PNAX.SetSweepMode(channel, sweepMode);
+                }
                 PNAX.WaitForOperationComplete();
             }
             catch (IndexOutOfRangeException ex)

--- a/OpenTap.Plugins.PNAX/LMS/StoreStatistics.cs
+++ b/OpenTap.Plugins.PNAX/LMS/StoreStatistics.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way

--- a/OpenTap.Plugins.PNAX/LMS/StoreStatistics.cs
+++ b/OpenTap.Plugins.PNAX/LMS/StoreStatistics.cs
@@ -1,0 +1,123 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using OpenTap.Plugins.PNAX.LMS;
+
+namespace OpenTap.Plugins.PNAX
+{
+    [Display("Store Statistics Data", Groups: new[] { "Network Analyzer", "Load/Measure/Store" }, Description: "Stores trace data from all channels.")]
+    public class StoreStatistics : StoreDataBase
+    {
+        #region Settings
+
+        [Display("MNum", Groups: new[] { "Trace" }, Order: 20)]
+        public int mnum { get; set; }
+
+        [Display("All Statistics", Group: "Settings", Order: 30)]
+        public bool AllData { get; set; }
+
+        [EnabledIf("AllData", false, HideIfDisabled = true)]
+        [Display("Statistic Type", Group: "Settings", Order: 31)]
+        public MathStatisticTypeEnum MathStatisticType { get; set; }
+
+        #endregion
+
+        public StoreStatistics()
+        {
+            channels = new List<int>() { 1 };
+            AllData = true;
+            MathStatisticType = MathStatisticTypeEnum.Ptp;
+        }
+
+        public override void Run()
+        {
+            MetaData = new List<(string, object)>();
+            UpgradeVerdict(Verdict.NotSet);
+
+            RunChildSteps(); //If the step supports child steps.
+
+            double result;
+
+            if (AllData)
+            {
+                MathStatisticType = MathStatisticTypeEnum.Ptp | MathStatisticTypeEnum.Std | MathStatisticTypeEnum.Mean | MathStatisticTypeEnum.Min | MathStatisticTypeEnum.Max;
+            }
+
+            foreach (int Channel in channels)
+            {
+                List<string> ResultNames = new List<string>();
+                List<IConvertible> ResultValues = new List<IConvertible>();
+
+                if (MathStatisticType.HasFlag(MathStatisticTypeEnum.Ptp))
+                {
+                    PNAX.MathExecuteStatistics(Channel, mnum);
+                    PNAX.MathType(Channel, mnum, MathStatisticTypeEnum.Ptp);
+                    result = PNAX.MathData(Channel, mnum);
+                    Log.Info($"Peak to Peak: {result}");
+                    ResultNames.Add(MathStatisticTypeEnum.Ptp.ToString());
+                    ResultValues.Add((IConvertible)result);
+                }
+                if (MathStatisticType.HasFlag(MathStatisticTypeEnum.Std))
+                {
+                    PNAX.MathExecuteStatistics(Channel, mnum);
+                    PNAX.MathType(Channel, mnum, MathStatisticTypeEnum.Std);
+                    result = PNAX.MathData(Channel, mnum);
+                    Log.Info($"Std dev: {result}");
+                    ResultNames.Add(MathStatisticTypeEnum.Std.ToString());
+                    ResultValues.Add((IConvertible)result);
+                }
+                if (MathStatisticType.HasFlag(MathStatisticTypeEnum.Mean))
+                {
+                    PNAX.MathExecuteStatistics(Channel, mnum);
+                    PNAX.MathType(Channel, mnum, MathStatisticTypeEnum.Mean);
+                    result = PNAX.MathData(Channel, mnum);
+                    Log.Info($"Mean: {result}");
+                    ResultNames.Add(MathStatisticTypeEnum.Mean.ToString());
+                    ResultValues.Add((IConvertible)result);
+                }
+                if (MathStatisticType.HasFlag(MathStatisticTypeEnum.Min))
+                {
+                    PNAX.MathExecuteStatistics(Channel, mnum);
+                    PNAX.MathType(Channel, mnum, MathStatisticTypeEnum.Min);
+                    result = PNAX.MathData(Channel, mnum);
+                    Log.Info($"Min: {result}");
+                    ResultNames.Add(MathStatisticTypeEnum.Min.ToString());
+                    ResultValues.Add((IConvertible)result);
+                }
+                if (MathStatisticType.HasFlag(MathStatisticTypeEnum.Max))
+                {
+                    PNAX.MathExecuteStatistics(Channel, mnum);
+                    PNAX.MathType(Channel, mnum, MathStatisticTypeEnum.Max);
+                    result = PNAX.MathData(Channel, mnum);
+                    Log.Info($"Max: {result}");
+                    ResultNames.Add(MathStatisticTypeEnum.Max.ToString());
+                    ResultValues.Add((IConvertible)result);
+                }
+
+                //if MetaData available
+                if ((MetaData != null) && (MetaData.Count > 0))
+                {
+                    // for every item in metadata
+                    for (int i = 0; i < MetaData.Count; i++)
+                    {
+                        ResultNames.Add(MetaData[i].Item1);
+                        ResultValues.Add((IConvertible)MetaData[i].Item2);
+                    }
+                }
+
+                Results.Publish($"Statistics_Data_Channel_{Channel.ToString()}", ResultNames, ResultValues.ToArray());
+            }
+
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}

--- a/OpenTap.Plugins.PNAX/Traces/TraceStatistics.cs
+++ b/OpenTap.Plugins.PNAX/Traces/TraceStatistics.cs
@@ -1,0 +1,172 @@
+﻿// Author: MyName
+// Copyright:   Copyright 2024 Keysight Technologies
+//              You have a royalty-free right to use, modify, reproduce and distribute
+//              the sample application files (and/or any modified version) in any way
+//              you find useful, provided that you agree that Keysight Technologies has no
+//              warranty, obligations or liability for any sample application files.
+using OpenTap;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenTap.Plugins.PNAX
+{
+    [AllowAsChildIn(typeof(TestPlan))]
+    [AllowAsChildIn(typeof(SingleTraceBaseStep))]
+    [Display("Statistics", Groups: new[] { "Network Analyzer", "Trace" }, Description: "Set Statistics for a trace")]
+    public class TraceStatistics : PNABaseStep
+    {
+        #region Settings
+        // Override for Channel so we can call ShowTraceSettings
+        private int _Channel;
+        [EnabledIf("IsControlledByParent", false, HideIfDisabled = false)]
+        [Display("Channel", Order: 0.11)]
+        public override int Channel
+        {
+            get
+            {
+                ShowTraceSettings();
+                return _Channel;
+            }
+            set
+            {
+                ShowTraceSettings();
+                _Channel = value;
+
+                // Update traces
+                foreach (var a in ChildTestSteps)
+                {
+                    if (a.GetType().IsSubclassOf(typeof(PNABaseStep)))
+                    {
+                        (a as PNABaseStep).Channel = value;
+                    }
+                    if (a is SingleTraceBaseStep)
+                    {
+                        (a as SingleTraceBaseStep).UpdateTestStepName();
+                    }
+                }
+            }
+        }
+
+        [EnabledIf("IsControlledByParent", false,HideIfDisabled = true)]
+        [Display("Window (standalone)", Groups: new[] { "Trace" }, Order: 14)]
+        public int Window { get; set; }
+
+        [EnabledIf("IsControlledByParent", false, HideIfDisabled = true)]
+        [Display("MNum (standalone)", Groups: new[] { "Trace" }, Order: 21)]
+        public int mnum { get; set; }
+
+        [Display("Enable Statistics", Groups: new[] { "Trace Statistics" }, Order: 30)]
+        public bool EnableStatistics { get; set; }
+
+        [Display("Statistics Range", Groups: new[] { "Trace Statistics" }, Order: 31)]
+        public MathStatisticsRangeEnum MathStatisticsRange { get; set; }
+
+        [EnabledIf("MathStatisticsRange", MathStatisticsRangeEnum.User1, MathStatisticsRangeEnum.User2, MathStatisticsRangeEnum.User3
+            , MathStatisticsRangeEnum.User4, MathStatisticsRangeEnum.User5, MathStatisticsRangeEnum.User6
+            , MathStatisticsRangeEnum.User7, MathStatisticsRangeEnum.User8, MathStatisticsRangeEnum.User9
+            , MathStatisticsRangeEnum.User10, MathStatisticsRangeEnum.User11, MathStatisticsRangeEnum.User12
+            , MathStatisticsRangeEnum.User13, MathStatisticsRangeEnum.User14, MathStatisticsRangeEnum.User15
+            , MathStatisticsRangeEnum.User16, HideIfDisabled = true)]
+        [Display("User Start", Groups: new[] { "Trace Statistics" }, Order: 32)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double UserStart { get; set; }
+
+        [EnabledIf("MathStatisticsRange", MathStatisticsRangeEnum.User1, MathStatisticsRangeEnum.User2, MathStatisticsRangeEnum.User3
+            , MathStatisticsRangeEnum.User4, MathStatisticsRangeEnum.User5, MathStatisticsRangeEnum.User6
+            , MathStatisticsRangeEnum.User7, MathStatisticsRangeEnum.User8, MathStatisticsRangeEnum.User9
+            , MathStatisticsRangeEnum.User10, MathStatisticsRangeEnum.User11, MathStatisticsRangeEnum.User12
+            , MathStatisticsRangeEnum.User13, MathStatisticsRangeEnum.User14, MathStatisticsRangeEnum.User15
+            , MathStatisticsRangeEnum.User16, HideIfDisabled = true)]
+        [Display("User Stop", Groups: new[] { "Trace Statistics" }, Order: 33)]
+        [Unit("Hz", UseEngineeringPrefix: true, StringFormat: "0.000000")]
+        public double UserStop { get; set; }
+
+        [Display("Show Smith Chart statistics in Ohms", Groups: new[] { "Trace Statistics" }, Order: 34)]
+        public bool ShowResistance { get; set; }
+
+
+        #endregion
+
+        private void ShowTraceSettings()
+        {
+            // What type of parent test we have?
+            if (this.Parent != null)
+            {
+                Type parType = this.Parent.GetType();
+                if (parType.Equals(typeof(TestPlan)))
+                {
+                    IsControlledByParent = false;
+                }
+                else
+                {
+                    // Parent must be a SingleTraceBaseStep
+                    IsControlledByParent = true;
+                }
+            }
+        }
+
+        public TraceStatistics()
+        {
+            Window = 1;
+            mnum = 1;
+            Channel = 1;
+
+            EnableStatistics = false;
+            MathStatisticsRange = MathStatisticsRangeEnum.FullSpan;
+            UserStart = 100e3;
+            UserStop = 44e9;
+            ShowResistance = false;
+        }
+
+        public override void Run()
+        {
+            PNAX.MathStatistics(Channel, mnum, EnableStatistics);
+            if (EnableStatistics)
+            {
+                PNAX.MathStatisticsRange(Channel, mnum, MathStatisticsRange);
+                if (MathStatisticsRange != MathStatisticsRangeEnum.FullSpan)
+                {
+                    PNAX.MathStatisticsRangeStart(Channel, mnum, MathStatisticsRange, UserStart);
+                    PNAX.MathStatisticsRangeStop(Channel, mnum, MathStatisticsRange, UserStop);
+                }
+                PNAX.MathShowResistance(Channel, mnum, ShowResistance);
+            }
+
+            UpgradeVerdict(Verdict.Pass);
+            UpdateMetaData();
+        }
+
+        [Browsable(false)]
+        public override List<(string, object)> GetMetaData()
+        {
+            List<(string, object)> retVal = new List<(string, object)>();
+
+            retVal.Add(("Channel", Channel));
+            retVal.Add(("EnableStatistics", EnableStatistics));
+            retVal.Add(("MathStatisticsRange", MathStatisticsRange));
+            if (MathStatisticsRange != MathStatisticsRangeEnum.FullSpan)
+            {
+                retVal.Add(("UserStart", UserStart));
+                retVal.Add(("UserStop", UserStop));
+            }
+            retVal.Add(("ShowResistance", ShowResistance));
+
+            return retVal;
+        }
+
+        public override void UpdateMetaData()
+        {
+            MetaData = new List<(string, object)> { ("Channel", Channel) };
+
+            List<(string, object)> ret = GetMetaData();
+            foreach (var it in ret)
+            {
+                MetaData.Add(it);
+            }
+        }
+
+    }
+}

--- a/OpenTap.Plugins.PNAX/Traces/TraceStatistics.cs
+++ b/OpenTap.Plugins.PNAX/Traces/TraceStatistics.cs
@@ -1,4 +1,4 @@
-﻿// Author: MyName
+﻿// Author: CMontes
 // Copyright:   Copyright 2024 Keysight Technologies
 //              You have a royalty-free right to use, modify, reproduce and distribute
 //              the sample application files (and/or any modified version) in any way
@@ -123,6 +123,11 @@ namespace OpenTap.Plugins.PNAX
 
         public override void Run()
         {
+            if (IsControlledByParent)
+            {
+                mnum = GetParent<SingleTraceBaseStep>().mnum;
+            }
+
             PNAX.MathStatistics(Channel, mnum, EnableStatistics);
             if (EnableStatistics)
             {

--- a/OpenTap.Plugins.PNAX/Traces/TraceStatistics.cs
+++ b/OpenTap.Plugins.PNAX/Traces/TraceStatistics.cs
@@ -126,6 +126,7 @@ namespace OpenTap.Plugins.PNAX
             if (IsControlledByParent)
             {
                 mnum = GetParent<SingleTraceBaseStep>().mnum;
+                Channel = GetParent<SingleTraceBaseStep>().Channel;
             }
 
             PNAX.MathStatistics(Channel, mnum, EnableStatistics);


### PR DESCRIPTION
Added MOD and MODX measurement classes
Added Save MOD table (Save table using instrument Save As and transfer to computer) and MOD Get Data (Query Parameters from the modulation distortion table)
Added Math Statistics, this step can be added to any single trace 
Added Store Statistics 
Added option to set Reference Oscillator in the instrument setup

All changes tested and validated by SoCa SE team, screen shots and results:

![image](https://github.com/opentap/Network-Analyzer/assets/101351788/3ec594af-fffc-48dd-a5e9-338c591b7596)

![image](https://github.com/opentap/Network-Analyzer/assets/101351788/3cb5c9de-8ce8-4b58-9517-caca4266cf9f)

[MOD_Data_Channel_1-2024-02-07 13-04-29-Pass.csv](https://github.com/opentap/Network-Analyzer/files/14204494/MOD_Data_Channel_1-2024-02-07.13-04-29-Pass.csv)

[Statistics_Data_Channel_1-2024-02-07 13-04-29-Pass.csv](https://github.com/opentap/Network-Analyzer/files/14204496/Statistics_Data_Channel_1-2024-02-07.13-04-29-Pass.csv)

Close #128 