### PR TITLE
Cal All updates

### DIFF
--- a/OpenTap.Plugins.PNAX/Acquisition/StoreSnp.cs
+++ b/OpenTap.Plugins.PNAX/Acquisition/StoreSnp.cs
@@ -71,14 +71,17 @@ namespace OpenTap.Plugins.PNAX.LMS
             UpgradeVerdict(Verdict.NotSet);
 
             string dir = "";
+            // Port Count to Update file extension s<n>p
+            int PortCount = Ports.Count;
+
             if (IsCustomPath)
             {
-                dir = Path.Combine(CustomPath.Expand(PlanRun), filename.Expand(PlanRun) + ".s2p"); ;
+                dir = Path.Combine(CustomPath.Expand(PlanRun), filename.Expand(PlanRun) + $".s{PortCount}p"); ;
             }
             else
             {
                 String assemblyDir = AssemblyDirectory();
-                dir = Path.Combine(assemblyDir, "Results", filename.Expand(PlanRun) + ".s2p");
+                dir = Path.Combine(assemblyDir, "Results", filename.Expand(PlanRun) + $".s{PortCount}p");
             }
 
             PNAX.SaveSnP(Channel.Value, mnum.Value, Ports, dir);

--- a/OpenTap.Plugins.PNAX/Calibration/CalAll.cs
+++ b/OpenTap.Plugins.PNAX/Calibration/CalAll.cs
@@ -584,53 +584,162 @@ namespace OpenTap.Plugins.PNAX
 
         private void DoHeadlessModeTasks()
         {
+            int nRetry = 0;
+
             if (HeadlessMode)
             {
-                // query the connected calkit and add it automatically
-                const string defaultKit = "85032F";
-                if (IsPort1CalKitEnabled)
+                do
                 {
-                    int CalChannel = PNAX.CalAllGuidedChannelNumber();
-                    string kits = PNAX.CalAllGetCalKits(CalChannel, Port1);
-                    string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
-                    selectedKit = selectedKit == "" ? defaultKit : selectedKit;
-                    Port1CalKit = selectedKit;
-                    Log.Debug($"Port1 calkit set to: {selectedKit}");
-                }
-                if (IsPort2CalKitEnabled)
-                {
-                    int CalChannel = PNAX.CalAllGuidedChannelNumber();
-                    string kits = PNAX.CalAllGetCalKits(CalChannel, Port2);
-                    string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
-                    selectedKit = selectedKit == "" ? defaultKit : selectedKit;
-                    Port2CalKit = selectedKit;
-                    Log.Debug($"Port2 calkit set to: {selectedKit}");
-                }
-                if (IsPort3CalKitEnabled)
-                {
-                    int CalChannel = PNAX.CalAllGuidedChannelNumber();
-                    string kits = PNAX.CalAllGetCalKits(CalChannel, Port3);
-                    string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
-                    selectedKit = selectedKit == "" ? defaultKit : selectedKit;
-                    Port3CalKit = selectedKit;
-                    Log.Debug($"Port4 calkit set to: {selectedKit}");
-                }
-                if (IsPort4CalKitEnabled)
-                {
-                    int CalChannel = PNAX.CalAllGuidedChannelNumber();
-                    string kits = PNAX.CalAllGetCalKits(CalChannel, Port4);
-                    string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
-                    selectedKit = selectedKit == "" ? defaultKit : selectedKit;
-                    Port4CalKit = selectedKit;
-                    Log.Debug($"Port4 calkit set to: {selectedKit}");
-                }
+                    // Ask user for connector types
+                    var dialog = new SelectConnectorTypeDialog(Port1, Port2, Port3, Port4);
+                    UserInput.Request(dialog);
 
-                // enable Power Calibration if appropriate
-                if (IsPowerCalEnabled)
-                {
-                    PNAX.CalAllSetProperty("Include Power Calibration", HeadlessPowerCalibration.ToString());
-                    Log.Debug($"Power calibration set");
-                }
+                    // Response from the user.
+                    if (dialog.Response == WaitForInputResult.Cancel)
+                    {
+                        Log.Info("Select cal kit aborted!");
+                    }
+                    Log.Info("Selected Port1: " + dialog.Port1);
+                    Log.Info("Selected Port2: " + dialog.Port2);
+                    Log.Info("Selected Port3: " + dialog.Port3);
+                    Log.Info("Selected Port4: " + dialog.Port4);
+
+                    // query the calkit for this type of connector and add it automatically
+                    const string defaultKit = "85032F";
+                    if (IsPort1CalKitEnabled)
+                    {
+                        int CalChannel = PNAX.CalAllGuidedChannelNumber();
+
+                        // Select Connector Type
+                        String strDutPort1 = Scpi.Format("{0}", Port1);
+                        PNAX.CalAllSelectDutConnectorType(CalChannel, 1, strDutPort1);
+
+                        // Get Kits
+                        string kits = PNAX.CalAllGetCalKits(CalChannel, Port1);
+                        string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
+                        selectedKit = selectedKit == "" ? defaultKit : selectedKit;
+                        Port1CalKit = selectedKit;
+                        Log.Debug($"Port1 calkit set to: {selectedKit}");
+
+                        if (selectedKit.Contains("ECal"))
+                        {
+                            // We selecte a valid ECal calkit
+                        }
+                        else
+                        {
+                            // Looks like we don't have a valid ECAL
+                            // Ask the user to provide a valid port
+                            var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
+                            UserInput.Request(dialogError);
+
+                            // next iteration
+                            continue;
+                        }
+                    }
+                    if (IsPort2CalKitEnabled)
+                    {
+                        int CalChannel = PNAX.CalAllGuidedChannelNumber();
+
+                        // Select Connector Type
+                        String strDutPort2 = Scpi.Format("{0}", Port2);
+                        PNAX.CalAllSelectDutConnectorType(CalChannel, 2, strDutPort2);
+
+                        // Get Kits
+                        string kits = PNAX.CalAllGetCalKits(CalChannel, Port2);
+                        string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
+                        selectedKit = selectedKit == "" ? defaultKit : selectedKit;
+                        Port2CalKit = selectedKit;
+                        Log.Debug($"Port2 calkit set to: {selectedKit}");
+
+                        if (selectedKit.Contains("ECal"))
+                        {
+                            // We selecte a valid ECal calkit
+                        }
+                        else
+                        {
+                            // Looks like we don't have a valid ECAL
+                            // Ask the user to provide a valid port
+                            var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
+                            UserInput.Request(dialogError);
+
+                            // next iteration
+                            continue;
+                        }
+                    }
+                    if (IsPort3CalKitEnabled)
+                    {
+                        int CalChannel = PNAX.CalAllGuidedChannelNumber();
+
+                        // Select Connector Type
+                        String strDutPort3 = Scpi.Format("{0}", Port3);
+                        PNAX.CalAllSelectDutConnectorType(CalChannel, 3, strDutPort3);
+
+                        // Get Kits
+                        string kits = PNAX.CalAllGetCalKits(CalChannel, Port3);
+                        string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
+                        selectedKit = selectedKit == "" ? defaultKit : selectedKit;
+                        Port3CalKit = selectedKit;
+                        Log.Debug($"Port4 calkit set to: {selectedKit}");
+                        
+                        if (selectedKit.Contains("ECal"))
+                        {
+                            // We selecte a valid ECal calkit
+                        }
+                        else
+                        {
+                            // Looks like we don't have a valid ECAL
+                            // Ask the user to provide a valid port
+                            var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
+                            UserInput.Request(dialogError);
+
+                            // next iteration
+                            continue;
+                        }
+                    }
+                    if (IsPort4CalKitEnabled)
+                    {
+                        int CalChannel = PNAX.CalAllGuidedChannelNumber();
+
+                        // Select Connector Type
+                        String strDutPort4 = Scpi.Format("{0}", Port4);
+                        PNAX.CalAllSelectDutConnectorType(CalChannel, 4, strDutPort4);
+
+                        // Get Kits
+                        string kits = PNAX.CalAllGetCalKits(CalChannel, Port4);
+                        string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
+                        selectedKit = selectedKit == "" ? defaultKit : selectedKit;
+                        Port4CalKit = selectedKit;
+                        Log.Debug($"Port4 calkit set to: {selectedKit}");
+
+                        if (selectedKit.Contains("ECal"))
+                        {
+                            // We selecte a valid ECal calkit
+                        }
+                        else
+                        {
+                            // Looks like we don't have a valid ECAL
+                            // Ask the user to provide a valid port
+                            var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
+                            UserInput.Request(dialogError);
+
+                            // next iteration
+                            continue;
+                        }
+                    }
+
+                    // enable Power Calibration if appropriate
+                    if (IsPowerCalEnabled)
+                    {
+                        PNAX.CalAllSetProperty("Include Power Calibration", HeadlessPowerCalibration.ToString());
+                        Log.Debug($"Power calibration set");
+                    }
+                    return;
+                } while (nRetry++ < 2);
+
+                var dialogError2 = new CalStepErrorMessageDialog("Could not find a valid CalKit after 3 tries!");
+                UserInput.Request(dialogError2);
+
+                throw new Exception("Could not find a valid CalKit after 3 tries!");
             }
         }
         
@@ -879,6 +988,78 @@ namespace OpenTap.Plugins.PNAX
         [AvailableValues(nameof(CalKits))]
         public string SelectedValue { get; set; }
 
+
+        [Layout(LayoutMode.FloatBottom | LayoutMode.FullRow)] // Show the button selection at the bottom of the window.
+        [Submit] // When the button is clicked the result is 'submitted', so the dialog is closed.
+        public WaitForInputResult Response { get; set; }
+
+        string IDisplayAnnotation.Description => string.Empty;
+
+        string[] IDisplayAnnotation.Group => Array.Empty<string>();
+
+        double IDisplayAnnotation.Order => -10000;
+
+        bool IDisplayAnnotation.Collapsed => false;
+    }
+
+    class SelectConnectorTypeDialog : IDisplayAnnotation
+    {
+        public SelectConnectorTypeDialog(DUTConnectorsEnum Port1Input, DUTConnectorsEnum Port2Input, DUTConnectorsEnum Port3Input, DUTConnectorsEnum Port4Input )
+        {
+            Port1 = Port1Input;
+            Port2 = Port2Input;
+            Port3 = Port3Input;
+            Port4 = Port4Input;
+        }
+
+
+        public string Name { get { return "Select Connector Types"; } }
+
+
+
+        [Display("Port 1 Connector", "Select the connector type for Port 1")]
+        public DUTConnectorsEnum Port1  { get; set; }
+
+        [Display("Port 2 Connector", "Select the connector type for Port 2")]
+        public DUTConnectorsEnum Port2 { get; set; }
+        
+        [Display("Port 3 Connector", "Select the connector type for Port 3")]
+        public DUTConnectorsEnum Port3 { get; set; }
+        
+        [Display("Port 4 Connector", "Select the connector type for Port 4")]
+        public DUTConnectorsEnum Port4 { get; set; }
+
+
+        [Layout(LayoutMode.FloatBottom | LayoutMode.FullRow)] // Show the button selection at the bottom of the window.
+        [Submit] // When the button is clicked the result is 'submitted', so the dialog is closed.
+        public WaitForInputResult Response { get; set; }
+
+        string IDisplayAnnotation.Description => string.Empty;
+
+        string[] IDisplayAnnotation.Group => Array.Empty<string>();
+
+        double IDisplayAnnotation.Order => -10000;
+
+        bool IDisplayAnnotation.Collapsed => false;
+    }
+
+    class CalStepErrorMessageDialog : IDisplayAnnotation
+    {
+        public CalStepErrorMessageDialog(String stepDescription)
+        {
+            StepDescription = stepDescription;
+        }
+
+        [Browsable(false)]
+        public String StepDescription { get; set; }
+
+        // Name is handled specially to create the title of the dialog window.
+        public string Name { get { return "Error selecting Connector Type and Calkit"; } }
+
+        [Layout(LayoutMode.FullRow, rowHeight: 2)]
+        [Browsable(true)] // Show it event though it is read-only.
+        [Display("Message", Order: 1)]
+        public string Message { get { return StepDescription; } }
 
         [Layout(LayoutMode.FloatBottom | LayoutMode.FullRow)] // Show the button selection at the bottom of the window.
         [Submit] // When the button is clicked the result is 'submitted', so the dialog is closed.

--- a/OpenTap.Plugins.PNAX/Calibration/CalAll.cs
+++ b/OpenTap.Plugins.PNAX/Calibration/CalAll.cs
@@ -582,7 +582,7 @@ namespace OpenTap.Plugins.PNAX
             return retString;
         }
 
-        private void DoHeadlessModeTasks()
+        private Verdict DoHeadlessModeTasks()
         {
             int nRetry = 0;
 
@@ -632,6 +632,10 @@ namespace OpenTap.Plugins.PNAX
                             var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
                             UserInput.Request(dialogError);
 
+                            // Fail
+                            Log.Info($"Could not find ECal for Port 1 connector type: {Port1}");
+                            return Verdict.Fail;
+
                             // next iteration
                             continue;
                         }
@@ -661,6 +665,10 @@ namespace OpenTap.Plugins.PNAX
                             // Ask the user to provide a valid port
                             var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
                             UserInput.Request(dialogError);
+
+                            // Fail
+                            Log.Info($"Could not find ECal for Port 2 connector type: {Port2}");
+                            return Verdict.Fail;
 
                             // next iteration
                             continue;
@@ -692,6 +700,10 @@ namespace OpenTap.Plugins.PNAX
                             var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
                             UserInput.Request(dialogError);
 
+                            // Fail
+                            Log.Info($"Could not find ECal for Port 3 connector type: {Port3}");
+                            return Verdict.Fail;
+
                             // next iteration
                             continue;
                         }
@@ -722,6 +734,10 @@ namespace OpenTap.Plugins.PNAX
                             var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
                             UserInput.Request(dialogError);
 
+                            // Fail
+                            Log.Info($"Could not find ECal for Port 4 connector type: {Port4}");
+                            return Verdict.Fail;
+
                             // next iteration
                             continue;
                         }
@@ -733,19 +749,26 @@ namespace OpenTap.Plugins.PNAX
                         PNAX.CalAllSetProperty("Include Power Calibration", HeadlessPowerCalibration.ToString());
                         Log.Debug($"Power calibration set");
                     }
-                    return;
+                    return Verdict.Pass;
                 } while (nRetry++ < 2);
 
                 var dialogError2 = new CalStepErrorMessageDialog("Could not find a valid CalKit after 3 tries!");
                 UserInput.Request(dialogError2);
 
                 throw new Exception("Could not find a valid CalKit after 3 tries!");
+                return Verdict.Fail;
             }
+            return Verdict.Pass;
         }
         
         public override void Run()
         {
-            DoHeadlessModeTasks();
+            if (DoHeadlessModeTasks() == Verdict.Fail)
+            {
+                Log.Info("Headless task failed!");
+                UpgradeVerdict(Verdict.Fail);
+                return;
+            }
 
             PNAX.CalAllReset();
 

--- a/OpenTap.Plugins.PNAX/Calibration/CalAll.cs
+++ b/OpenTap.Plugins.PNAX/Calibration/CalAll.cs
@@ -584,25 +584,25 @@ namespace OpenTap.Plugins.PNAX
 
         private Verdict DoHeadlessModeTasks()
         {
-            int nRetry = 0;
+            //int nRetry = 0;
 
             if (HeadlessMode)
             {
-                do
-                {
-                    // Ask user for connector types
-                    var dialog = new SelectConnectorTypeDialog(Port1, Port2, Port3, Port4);
-                    UserInput.Request(dialog);
+                //do
+                //{
+                    //// Ask user for connector types
+                    //var dialog = new SelectConnectorTypeDialog(Port1, Port2, Port3, Port4);
+                    //UserInput.Request(dialog);
 
-                    // Response from the user.
-                    if (dialog.Response == WaitForInputResult.Cancel)
-                    {
-                        Log.Info("Select cal kit aborted!");
-                    }
-                    Log.Info("Selected Port1: " + dialog.Port1);
-                    Log.Info("Selected Port2: " + dialog.Port2);
-                    Log.Info("Selected Port3: " + dialog.Port3);
-                    Log.Info("Selected Port4: " + dialog.Port4);
+                    //// Response from the user.
+                    //if (dialog.Response == WaitForInputResult.Cancel)
+                    //{
+                    //    Log.Info("Select cal kit aborted!");
+                    //}
+                    //Log.Info("Selected Port1: " + dialog.Port1);
+                    //Log.Info("Selected Port2: " + dialog.Port2);
+                    //Log.Info("Selected Port3: " + dialog.Port3);
+                    //Log.Info("Selected Port4: " + dialog.Port4);
 
                     // query the calkit for this type of connector and add it automatically
                     const string defaultKit = "85032F";
@@ -632,13 +632,13 @@ namespace OpenTap.Plugins.PNAX
                             Log.Info($"Could not find ECal for Port 1 connector type: {Port1}");
                             return Verdict.Fail;
 
-                            // Looks like we don't have a valid ECAL
-                            // Ask the user to provide a valid port
-                            var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
-                            UserInput.Request(dialogError);
+                            //// Looks like we don't have a valid ECAL
+                            //// Ask the user to provide a valid port
+                            //var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
+                            //UserInput.Request(dialogError);
 
-                            // next iteration
-                            continue;
+                            //// next iteration
+                            //continue;
                         }
                     }
                     if (IsPort2CalKitEnabled)
@@ -667,13 +667,13 @@ namespace OpenTap.Plugins.PNAX
                             Log.Info($"Could not find ECal for Port 2 connector type: {Port2}");
                             return Verdict.Fail;
 
-                            // Looks like we don't have a valid ECAL
-                            // Ask the user to provide a valid port
-                            var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
-                            UserInput.Request(dialogError);
+                            //// Looks like we don't have a valid ECAL
+                            //// Ask the user to provide a valid port
+                            //var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
+                            //UserInput.Request(dialogError);
 
-                            // next iteration
-                            continue;
+                            //// next iteration
+                            //continue;
                         }
                     }
                     if (IsPort3CalKitEnabled)
@@ -702,13 +702,13 @@ namespace OpenTap.Plugins.PNAX
                             Log.Info($"Could not find ECal for Port 3 connector type: {Port3}");
                             return Verdict.Fail;
 
-                            // Looks like we don't have a valid ECAL
-                            // Ask the user to provide a valid port
-                            var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
-                            UserInput.Request(dialogError);
+                            //// Looks like we don't have a valid ECAL
+                            //// Ask the user to provide a valid port
+                            //var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
+                            //UserInput.Request(dialogError);
 
-                            // next iteration
-                            continue;
+                            //// next iteration
+                            //continue;
                         }
                     }
                     if (IsPort4CalKitEnabled)
@@ -737,13 +737,13 @@ namespace OpenTap.Plugins.PNAX
                             Log.Info($"Could not find ECal for Port 4 connector type: {Port4}");
                             return Verdict.Fail;
 
-                            // Looks like we don't have a valid ECAL
-                            // Ask the user to provide a valid port
-                            var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
-                            UserInput.Request(dialogError);
+                            //// Looks like we don't have a valid ECAL
+                            //// Ask the user to provide a valid port
+                            //var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
+                            //UserInput.Request(dialogError);
 
-                            // next iteration
-                            continue;
+                            //// next iteration
+                            //continue;
                         }
                     }
 
@@ -754,13 +754,13 @@ namespace OpenTap.Plugins.PNAX
                         Log.Debug($"Power calibration set");
                     }
                     return Verdict.Pass;
-                } while (nRetry++ < 2);
+                //} while (nRetry++ < 2);
 
-                var dialogError2 = new CalStepErrorMessageDialog("Could not find a valid CalKit after 3 tries!");
-                UserInput.Request(dialogError2);
+                //var dialogError2 = new CalStepErrorMessageDialog("Could not find a valid CalKit after 3 tries!");
+                //UserInput.Request(dialogError2);
 
-                throw new Exception("Could not find a valid CalKit after 3 tries!");
-                return Verdict.Fail;
+                //throw new Exception("Could not find a valid CalKit after 3 tries!");
+                //return Verdict.Fail;
             }
             return Verdict.Pass;
         }

--- a/OpenTap.Plugins.PNAX/Calibration/CalAll.cs
+++ b/OpenTap.Plugins.PNAX/Calibration/CalAll.cs
@@ -249,7 +249,7 @@ namespace OpenTap.Plugins.PNAX
             set
             {
                 _Port4 = value;
-                if (_Port1 == DUTConnectorsEnum.Notused)
+                if (_Port4 == DUTConnectorsEnum.Notused)
                 {
                     IsPort4CalKitEnabled = false;
                 }

--- a/OpenTap.Plugins.PNAX/Calibration/CalAll.cs
+++ b/OpenTap.Plugins.PNAX/Calibration/CalAll.cs
@@ -624,17 +624,18 @@ namespace OpenTap.Plugins.PNAX
                         if (selectedKit.Contains("ECal"))
                         {
                             // We selecte a valid ECal calkit
+                            Log.Info($"Valid ECal found for Port 1: {selectedKit}");
                         }
                         else
                         {
+                            // Fail
+                            Log.Info($"Could not find ECal for Port 1 connector type: {Port1}");
+                            return Verdict.Fail;
+
                             // Looks like we don't have a valid ECAL
                             // Ask the user to provide a valid port
                             var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
                             UserInput.Request(dialogError);
-
-                            // Fail
-                            Log.Info($"Could not find ECal for Port 1 connector type: {Port1}");
-                            return Verdict.Fail;
 
                             // next iteration
                             continue;
@@ -658,17 +659,18 @@ namespace OpenTap.Plugins.PNAX
                         if (selectedKit.Contains("ECal"))
                         {
                             // We selecte a valid ECal calkit
+                            Log.Info($"Valid ECal found for Port 2: {selectedKit}");
                         }
                         else
                         {
+                            // Fail
+                            Log.Info($"Could not find ECal for Port 2 connector type: {Port2}");
+                            return Verdict.Fail;
+
                             // Looks like we don't have a valid ECAL
                             // Ask the user to provide a valid port
                             var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
                             UserInput.Request(dialogError);
-
-                            // Fail
-                            Log.Info($"Could not find ECal for Port 2 connector type: {Port2}");
-                            return Verdict.Fail;
 
                             // next iteration
                             continue;
@@ -692,17 +694,18 @@ namespace OpenTap.Plugins.PNAX
                         if (selectedKit.Contains("ECal"))
                         {
                             // We selecte a valid ECal calkit
+                            Log.Info($"Valid ECal found for Port 3: {selectedKit}");
                         }
                         else
                         {
+                            // Fail
+                            Log.Info($"Could not find ECal for Port 3 connector type: {Port3}");
+                            return Verdict.Fail;
+
                             // Looks like we don't have a valid ECAL
                             // Ask the user to provide a valid port
                             var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
                             UserInput.Request(dialogError);
-
-                            // Fail
-                            Log.Info($"Could not find ECal for Port 3 connector type: {Port3}");
-                            return Verdict.Fail;
 
                             // next iteration
                             continue;
@@ -726,17 +729,18 @@ namespace OpenTap.Plugins.PNAX
                         if (selectedKit.Contains("ECal"))
                         {
                             // We selecte a valid ECal calkit
+                            Log.Info($"Valid ECal found for Port 4: {selectedKit}");
                         }
                         else
                         {
+                            // Fail
+                            Log.Info($"Could not find ECal for Port 4 connector type: {Port4}");
+                            return Verdict.Fail;
+
                             // Looks like we don't have a valid ECAL
                             // Ask the user to provide a valid port
                             var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
                             UserInput.Request(dialogError);
-
-                            // Fail
-                            Log.Info($"Could not find ECal for Port 4 connector type: {Port4}");
-                            return Verdict.Fail;
 
                             // next iteration
                             continue;

--- a/OpenTap.Plugins.PNAX/Calibration/CalAll.cs
+++ b/OpenTap.Plugins.PNAX/Calibration/CalAll.cs
@@ -19,12 +19,14 @@ namespace OpenTap.Plugins.PNAX
         public Picture Picture { get; } = new Picture();
 
         [FilePath(FilePathAttribute.BehaviorChoice.Open)]
+        [Display("Picture Source", "File path for picture to be displayed.")]
         public string PictureSource
         {
             get => Picture.Source;
             set => Picture.Source = value;
         }
 
+        [Display("Picture Description", "Description of the picture to be displayed.")]
         public string PictureDescription
         {
             get => Picture.Description;

--- a/OpenTap.Plugins.PNAX/Calibration/CalAll.cs
+++ b/OpenTap.Plugins.PNAX/Calibration/CalAll.cs
@@ -607,183 +607,126 @@ namespace OpenTap.Plugins.PNAX
 
         private Verdict DoHeadlessModeTasks()
         {
-            //int nRetry = 0;
-
             if (HeadlessMode)
             {
-                //do
-                //{
-                    //// Ask user for connector types
-                    //var dialog = new SelectConnectorTypeDialog(Port1, Port2, Port3, Port4);
-                    //UserInput.Request(dialog);
+                // query the calkit for this type of connector and add it automatically
+                const string defaultKit = "85032F";
+                if (IsPort1CalKitEnabled)
+                {
+                    int CalChannel = PNAX.CalAllGuidedChannelNumber();
 
-                    //// Response from the user.
-                    //if (dialog.Response == WaitForInputResult.Cancel)
-                    //{
-                    //    Log.Info("Select cal kit aborted!");
-                    //}
-                    //Log.Info("Selected Port1: " + dialog.Port1);
-                    //Log.Info("Selected Port2: " + dialog.Port2);
-                    //Log.Info("Selected Port3: " + dialog.Port3);
-                    //Log.Info("Selected Port4: " + dialog.Port4);
+                    // Select Connector Type
+                    String strDutPort1 = Scpi.Format("{0}", Port1);
+                    PNAX.CalAllSelectDutConnectorType(CalChannel, 1, strDutPort1);
 
-                    // query the calkit for this type of connector and add it automatically
-                    const string defaultKit = "85032F";
-                    if (IsPort1CalKitEnabled)
+                    // Get Kits
+                    string kits = PNAX.CalAllGetCalKits(CalChannel, Port1);
+                    string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
+                    selectedKit = selectedKit == "" ? defaultKit : selectedKit;
+                    Port1CalKit = selectedKit;
+                    Log.Debug($"Port1 calkit set to: {selectedKit}");
+
+                    if (selectedKit.Contains("ECal"))
                     {
-                        int CalChannel = PNAX.CalAllGuidedChannelNumber();
-
-                        // Select Connector Type
-                        String strDutPort1 = Scpi.Format("{0}", Port1);
-                        PNAX.CalAllSelectDutConnectorType(CalChannel, 1, strDutPort1);
-
-                        // Get Kits
-                        string kits = PNAX.CalAllGetCalKits(CalChannel, Port1);
-                        string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
-                        selectedKit = selectedKit == "" ? defaultKit : selectedKit;
-                        Port1CalKit = selectedKit;
-                        Log.Debug($"Port1 calkit set to: {selectedKit}");
-
-                        if (selectedKit.Contains("ECal"))
-                        {
-                            // We selecte a valid ECal calkit
-                            Log.Info($"Valid ECal found for Port 1: {selectedKit}");
-                        }
-                        else
-                        {
-                            // Fail
-                            Log.Info($"Could not find ECal for Port 1 connector type: {Port1}");
-                            return Verdict.Fail;
-
-                            //// Looks like we don't have a valid ECAL
-                            //// Ask the user to provide a valid port
-                            //var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
-                            //UserInput.Request(dialogError);
-
-                            //// next iteration
-                            //continue;
-                        }
+                        // We selecte a valid ECal calkit
+                        Log.Info($"Valid ECal found for Port 1: {selectedKit}");
                     }
-                    if (IsPort2CalKitEnabled)
+                    else
                     {
-                        int CalChannel = PNAX.CalAllGuidedChannelNumber();
-
-                        // Select Connector Type
-                        String strDutPort2 = Scpi.Format("{0}", Port2);
-                        PNAX.CalAllSelectDutConnectorType(CalChannel, 2, strDutPort2);
-
-                        // Get Kits
-                        string kits = PNAX.CalAllGetCalKits(CalChannel, Port2);
-                        string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
-                        selectedKit = selectedKit == "" ? defaultKit : selectedKit;
-                        Port2CalKit = selectedKit;
-                        Log.Debug($"Port2 calkit set to: {selectedKit}");
-
-                        if (selectedKit.Contains("ECal"))
-                        {
-                            // We selecte a valid ECal calkit
-                            Log.Info($"Valid ECal found for Port 2: {selectedKit}");
-                        }
-                        else
-                        {
-                            // Fail
-                            Log.Info($"Could not find ECal for Port 2 connector type: {Port2}");
-                            return Verdict.Fail;
-
-                            //// Looks like we don't have a valid ECAL
-                            //// Ask the user to provide a valid port
-                            //var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
-                            //UserInput.Request(dialogError);
-
-                            //// next iteration
-                            //continue;
-                        }
+                        // Looks like we don't have a valid ECAL for Port 1 - Fail 
+                        Log.Info($"Could not find ECal for Port 1 connector type: {Port1}");
+                        return Verdict.Fail;
                     }
-                    if (IsPort3CalKitEnabled)
+                }
+                if (IsPort2CalKitEnabled)
+                {
+                    int CalChannel = PNAX.CalAllGuidedChannelNumber();
+
+                    // Select Connector Type
+                    String strDutPort2 = Scpi.Format("{0}", Port2);
+                    PNAX.CalAllSelectDutConnectorType(CalChannel, 2, strDutPort2);
+
+                    // Get Kits
+                    string kits = PNAX.CalAllGetCalKits(CalChannel, Port2);
+                    string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
+                    selectedKit = selectedKit == "" ? defaultKit : selectedKit;
+                    Port2CalKit = selectedKit;
+                    Log.Debug($"Port2 calkit set to: {selectedKit}");
+
+                    if (selectedKit.Contains("ECal"))
                     {
-                        int CalChannel = PNAX.CalAllGuidedChannelNumber();
-
-                        // Select Connector Type
-                        String strDutPort3 = Scpi.Format("{0}", Port3);
-                        PNAX.CalAllSelectDutConnectorType(CalChannel, 3, strDutPort3);
-
-                        // Get Kits
-                        string kits = PNAX.CalAllGetCalKits(CalChannel, Port3);
-                        string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
-                        selectedKit = selectedKit == "" ? defaultKit : selectedKit;
-                        Port3CalKit = selectedKit;
-                        Log.Debug($"Port4 calkit set to: {selectedKit}");
-                        
-                        if (selectedKit.Contains("ECal"))
-                        {
-                            // We selecte a valid ECal calkit
-                            Log.Info($"Valid ECal found for Port 3: {selectedKit}");
-                        }
-                        else
-                        {
-                            // Fail
-                            Log.Info($"Could not find ECal for Port 3 connector type: {Port3}");
-                            return Verdict.Fail;
-
-                            //// Looks like we don't have a valid ECAL
-                            //// Ask the user to provide a valid port
-                            //var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
-                            //UserInput.Request(dialogError);
-
-                            //// next iteration
-                            //continue;
-                        }
+                        // We selecte a valid ECal calkit
+                        Log.Info($"Valid ECal found for Port 2: {selectedKit}");
                     }
-                    if (IsPort4CalKitEnabled)
+                    else
                     {
-                        int CalChannel = PNAX.CalAllGuidedChannelNumber();
-
-                        // Select Connector Type
-                        String strDutPort4 = Scpi.Format("{0}", Port4);
-                        PNAX.CalAllSelectDutConnectorType(CalChannel, 4, strDutPort4);
-
-                        // Get Kits
-                        string kits = PNAX.CalAllGetCalKits(CalChannel, Port4);
-                        string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
-                        selectedKit = selectedKit == "" ? defaultKit : selectedKit;
-                        Port4CalKit = selectedKit;
-                        Log.Debug($"Port4 calkit set to: {selectedKit}");
-
-                        if (selectedKit.Contains("ECal"))
-                        {
-                            // We selecte a valid ECal calkit
-                            Log.Info($"Valid ECal found for Port 4: {selectedKit}");
-                        }
-                        else
-                        {
-                            // Fail
-                            Log.Info($"Could not find ECal for Port 4 connector type: {Port4}");
-                            return Verdict.Fail;
-
-                            //// Looks like we don't have a valid ECAL
-                            //// Ask the user to provide a valid port
-                            //var dialogError = new CalStepErrorMessageDialog("Please select a valid Connector Type");
-                            //UserInput.Request(dialogError);
-
-                            //// next iteration
-                            //continue;
-                        }
+                        // Looks like we don't have a valid ECAL for Port 2 - Fail 
+                        Log.Info($"Could not find ECal for Port 2 connector type: {Port2}");
+                        return Verdict.Fail;
                     }
+                }
+                if (IsPort3CalKitEnabled)
+                {
+                    int CalChannel = PNAX.CalAllGuidedChannelNumber();
 
-                    // enable Power Calibration if appropriate
-                    if (IsPowerCalEnabled)
+                    // Select Connector Type
+                    String strDutPort3 = Scpi.Format("{0}", Port3);
+                    PNAX.CalAllSelectDutConnectorType(CalChannel, 3, strDutPort3);
+
+                    // Get Kits
+                    string kits = PNAX.CalAllGetCalKits(CalChannel, Port3);
+                    string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
+                    selectedKit = selectedKit == "" ? defaultKit : selectedKit;
+                    Port3CalKit = selectedKit;
+                    Log.Debug($"Port3 calkit set to: {selectedKit}");
+
+                    if (selectedKit.Contains("ECal"))
                     {
-                        PNAX.CalAllSetProperty("Include Power Calibration", HeadlessPowerCalibration.ToString());
-                        Log.Debug($"Power calibration set");
+                        // We selecte a valid ECal calkit
+                        Log.Info($"Valid ECal found for Port 3: {selectedKit}");
                     }
-                    return Verdict.Pass;
-                //} while (nRetry++ < 2);
+                    else
+                    {
+                        // Looks like we don't have a valid ECAL for Port 3 - Fail 
+                        Log.Info($"Could not find ECal for Port 3 connector type: {Port3}");
+                        return Verdict.Fail;
+                    }
+                }
+                if (IsPort4CalKitEnabled)
+                {
+                    int CalChannel = PNAX.CalAllGuidedChannelNumber();
 
-                //var dialogError2 = new CalStepErrorMessageDialog("Could not find a valid CalKit after 3 tries!");
-                //UserInput.Request(dialogError2);
+                    // Select Connector Type
+                    String strDutPort4 = Scpi.Format("{0}", Port4);
+                    PNAX.CalAllSelectDutConnectorType(CalChannel, 4, strDutPort4);
 
-                //throw new Exception("Could not find a valid CalKit after 3 tries!");
-                //return Verdict.Fail;
+                    // Get Kits
+                    string kits = PNAX.CalAllGetCalKits(CalChannel, Port4);
+                    string selectedKit = kits.Split(',').FirstOrDefault(x => !x.Contains(defaultKit)).Trim(' ', '"');
+                    selectedKit = selectedKit == "" ? defaultKit : selectedKit;
+                    Port4CalKit = selectedKit;
+                    Log.Debug($"Port4 calkit set to: {selectedKit}");
+
+                    if (selectedKit.Contains("ECal"))
+                    {
+                        // We selecte a valid ECal calkit
+                        Log.Info($"Valid ECal found for Port 4: {selectedKit}");
+                    }
+                    else
+                    {
+                        // Looks like we don't have a valid ECAL for Port 4 - Fail 
+                        Log.Info($"Could not find ECal for Port 4 connector type: {Port4}");
+                        return Verdict.Fail;
+                    }
+                }
+
+                // enable Power Calibration if appropriate
+                if (IsPowerCalEnabled)
+                {
+                    PNAX.CalAllSetProperty("Include Power Calibration", HeadlessPowerCalibration.ToString());
+                    Log.Debug($"Power calibration set");
+                }
+                return Verdict.Pass;
             }
             return Verdict.Pass;
         }

--- a/OpenTap.Plugins.PNAX/Instrument/PNA.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNA.cs
@@ -125,6 +125,8 @@ namespace OpenTap.Plugins.PNAX
         [Display("Reference Out", "Set Reference out frequency", Group: "Reference", Order: 12)]
         public VNAReferenceFreqEnumtype VNAReferenceOut { get; set; }
 
+        [Display("Store SNP Black List", "Measurement Classes for which SNP can't be stored", Group: "Store SNP Settings", Order: 31, Collapsed: true)]
+        public List<String> StoreSnpBlackList { get; set; }
         #endregion
 
         public StandardChannelValues DefaultStandardChannelValues;
@@ -157,6 +159,8 @@ namespace OpenTap.Plugins.PNAX
             EnableReferenceOscillatorSettings = false;
             VNAReferenceIn = VNAReferenceInEnumtype.Internal;
             VNAReferenceOut = VNAReferenceFreqEnumtype.Ten;
+
+            StoreSnpBlackList = new List<string>() { "Differential I/Q", "Differential IQ" };
         }
 
         /// <summary>

--- a/OpenTap.Plugins.PNAX/Instrument/PNA.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNA.cs
@@ -125,8 +125,8 @@ namespace OpenTap.Plugins.PNAX
         [Display("Reference Out", "Set Reference out frequency", Group: "Reference", Order: 12)]
         public VNAReferenceFreqEnumtype VNAReferenceOut { get; set; }
 
-        [Display("Store SNP Black List", "Measurement Classes for which SNP can't be stored", Group: "Store SNP Settings", Order: 31, Collapsed: true)]
-        public List<String> StoreSnpBlackList { get; set; }
+        [Display("Store SNP Block List", "Measurement Classes for which SNP can't be stored", Group: "Store SNP Settings", Order: 31, Collapsed: true)]
+        public List<String> StoreSnpBlockList { get; set; }
         #endregion
 
         public StandardChannelValues DefaultStandardChannelValues;
@@ -160,7 +160,7 @@ namespace OpenTap.Plugins.PNAX
             VNAReferenceIn = VNAReferenceInEnumtype.Internal;
             VNAReferenceOut = VNAReferenceFreqEnumtype.Ten;
 
-            StoreSnpBlackList = new List<string>() { "Differential I/Q", "Differential IQ" };
+            StoreSnpBlockList = new List<string>() { "Differential I/Q", "Differential IQ" };
         }
 
         /// <summary>

--- a/OpenTap.Plugins.PNAX/Instrument/PNACal.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNACal.cs
@@ -40,6 +40,24 @@ namespace OpenTap.Plugins.PNAX
         NoiseFigureConverters
     }
 
+
+    public enum PNAPowerMeterEnumtype
+    {
+        [Display("GPIB")]
+        [Scpi("GPIB")]
+        Gpib,
+        [Display("USB")]
+        [Scpi("USB")]
+        Usb,
+        [Display("LAN")]
+        [Scpi("LAN")]
+        Lan,
+        [Display("ANY")]
+        [Scpi("ANY")]
+        Any
+    }
+
+
     public class CalibrateAllSelectedChannels
     {
         public int Channel { get; set; }
@@ -482,6 +500,43 @@ namespace OpenTap.Plugins.PNAX
             int mode = ScpiQuery<int>("SYST:ACT:SIMulator?");
             return mode;
         }
+
+        public void SetPowerSensor(PNAPowerMeterEnumtype powerMeterType, string powerSensorString)
+        {
+            string pmType = Scpi.Format("{0}", powerMeterType);
+            ScpiCommand($"SYSTem:COMMunicate:PSENsor {pmType}, \"{powerSensorString}\"");
+        }
+
+        public string ReadConnectedSensor()
+        {
+            String str = ScpiQuery("SYSTem:COMMunicate:USB:PMETer:CATalog? OFF");
+            string selectedPowerSensor = str.Split(';').FirstOrDefault().Trim(' ', '"');
+            return selectedPowerSensor;
+        }
+
+        public void PowerMeterSettlingTolerance(double tolerance)
+        {
+            ScpiCommand($"SOURce:POWer:CORRection:COLLect:AVERage:NTOLerance {tolerance}");
+        }
+
+        public void PowerMeterSettlingMaxReadings(int readings)
+        {
+            ScpiCommand($"SOURce:POWer:CORRection:COLLect:AVERage:COUNt {readings}");
+        }
+
+        public void PowerMeterPowerLevel(int Channel, int port, double level)
+        {
+            //ScpiCommand($"SOURce<ch>:POWer<port>:CORRection:LEVel[:AMPLitude] <num>[,src]");
+            ScpiCommand($"SENSe{Channel}:CORRection:COLLect:GUIDed:PSENsor{port}:POWer:LEVel {level}");
+        }
+
+        public void PowerMeterSensorEnable(int Channel, int port, bool state)
+        {
+            string stateValue = state ? "ON" : "OFF";
+            ScpiCommand($"SENSe{Channel}:CORRection:COLLect:GUIDed:PSENsor{port}:STATe {stateValue}");
+        }
+
+
 
     }
 }

--- a/OpenTap.Plugins.PNAX/Instrument/PNACal.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNACal.cs
@@ -526,7 +526,6 @@ namespace OpenTap.Plugins.PNAX
 
         public void PowerMeterPowerLevel(int Channel, int port, double level)
         {
-            //ScpiCommand($"SOURce<ch>:POWer<port>:CORRection:LEVel[:AMPLitude] <num>[,src]");
             ScpiCommand($"SENSe{Channel}:CORRection:COLLect:GUIDed:PSENsor{port}:POWer:LEVel {level}");
         }
 

--- a/OpenTap.Plugins.PNAX/Instrument/PNALoadMeasStore.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNALoadMeasStore.cs
@@ -480,9 +480,9 @@ namespace OpenTap.Plugins.PNAX
                     ScpiCommand($"CALCulate{Channel}:MEASure{mnum}:DATA:SNP:PORTs:SAVE '{strPorts}','" + InstrumentFileName + "'");
                 }
             }
-            else if (StoreSnpBlackList.Any(s => s.Equals(measName)))
+            else if (StoreSnpBlockList.Any(s => s.Equals(measName)))
             {
-                // if meas name is in BlackList
+                // if meas name is in BlockList
                 Log.Info($"Can't store SNP for Channel '{Channel}' with Measurement Class '{measName}'");
                 return;
             }

--- a/OpenTap.Plugins.PNAX/Instrument/PNALoadMeasStore.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNALoadMeasStore.cs
@@ -465,18 +465,33 @@ namespace OpenTap.Plugins.PNAX
 
             ChangeFolder(InstrumentFolderName);
 
-            // Save screenshot to local folder on instrument: <documents>\<mode>\screen
-            //string opc = MyVNA.ScpiQuery("CALC:MEAS:DATA:SNP:PORTs:Save '1,2','C:\\Program Files\\Keysight\\Test Automation\\Results\\Traces\\MyData1.s2p';*OPC?");
-            // TODO PNA-L vs ENA
-            //ScpiCommand("CALC:MEAS:DATA:SNP:PORTs:Save '1,2','" + InstrumentFileName + "'");
-            if (IsModelA)
+            // Find Class Name
+            String measName = GetChannelType(Channel);
+
+            // if Standard
+            if (measName.Equals("Standard"))
             {
-                ScpiCommand($"CALCulate{Channel}:DATA:SNP:PORTs:SAVE '{strPorts}','" + InstrumentFileName + "'");
+                if (IsModelA)
+                {
+                    ScpiCommand($"CALCulate{Channel}:DATA:SNP:PORTs:SAVE '{strPorts}','" + InstrumentFileName + "'");
+                }
+                else
+                {
+                    ScpiCommand($"CALCulate{Channel}:MEASure{mnum}:DATA:SNP:PORTs:SAVE '{strPorts}','" + InstrumentFileName + "'");
+                }
+            }
+            else if (StoreSnpBlackList.Any(s => s.Equals(measName)))
+            {
+                // if meas name is in BlackList
+                Log.Info($"Can't store SNP for Channel '{Channel}' with Measurement Class '{measName}'");
+                return;
             }
             else
             {
-                ScpiCommand($"CALCulate{Channel}:MEASure{mnum}:DATA:SNP:PORTs:SAVE '{strPorts}','" + InstrumentFileName + "'");
+                // use MMEM:STOR
+                ScpiCommand($"MMEM:STORe '{InstrumentFileName}'");
             }
+
 
             // Make sure folder exists on local PC
             bool exists = System.IO.Directory.Exists(FilePath);

--- a/OpenTap.Plugins.PNAX/LMS/StoreSnp.cs
+++ b/OpenTap.Plugins.PNAX/LMS/StoreSnp.cs
@@ -76,16 +76,18 @@ namespace OpenTap.Plugins.PNAX.LMS
                 Log.Info("MNUMs for channel: " + string.Join<int>(",", measurements));
 
                 string dir = "";
+                // Port Count to Update file extension s<n>p
+                int PortCount = Ports.Count;
 
                 MacroString macroString = new MacroString(this) { Text = filename.Text + "_CH" + channel };
                 if (IsCustomPath)
                 {
-                    dir = Path.Combine(CustomPath.Expand(PlanRun), macroString.Expand(PlanRun) + ".s2p"); ;
+                    dir = Path.Combine(CustomPath.Expand(PlanRun), macroString.Expand(PlanRun) + $".s{PortCount}p"); ;
                 }
                 else
                 {
                     string assemblyDir = AssemblyDirectory();
-                    dir = Path.Combine(assemblyDir, "Results", macroString.Expand(PlanRun) + ".s2p");
+                    dir = Path.Combine(assemblyDir, "Results", macroString.Expand(PlanRun) + $".s{PortCount}p");
                 }
 
                 // Saving to file:

--- a/OpenTap.Plugins.PNAX/LMS/StoreSnp.cs
+++ b/OpenTap.Plugins.PNAX/LMS/StoreSnp.cs
@@ -29,9 +29,6 @@ namespace OpenTap.Plugins.PNAX.LMS
         [Display("Channel", Description: "Choose which channel to grab data from.", "Measurements", Order: 10)]
         public List<int> channels { get; set; }
 
-        //[Display("MNum", Groups: new[] { "Trace" }, Order: 21)]
-        //public int mnum { get; set; }
-
         [Display("Ports", Groups: new[] { "Trace" }, Order: 22)]
         public List<int> Ports { get; set; }
 
@@ -50,9 +47,8 @@ namespace OpenTap.Plugins.PNAX.LMS
         public StoreSnp()
         {
             channels = new List<int>() { 1 };
-            //mnum = 1;
             Ports = new List<int>() { 1, 2 };
-            filename = new MacroString(this) { Text = "<PartId>" };
+            filename = new MacroString(this) { Text = "MySnP" };
             IsCustomPath = false;
             CustomPath = new MacroString(this) { Text = @"C:\" };
         }

--- a/OpenTap.Plugins.PNAX/LMS/StoreSnp.cs
+++ b/OpenTap.Plugins.PNAX/LMS/StoreSnp.cs
@@ -22,11 +22,15 @@ namespace OpenTap.Plugins.PNAX.LMS
         [Display("PNA", Order: 0.1)]
         public PNAX PNAX { get; set; }
 
-        [Display("Channel", Description: "Choose which channel to grab data from.", "Measurements", Order: 10)]
-        public int Channel { get; set; }
+        [Display("Auto Select All Channels", Group: "Measurements", Order: 10)]
+        public bool AutoSelectChannels { get; set; }
 
-        [Display("MNum", Groups: new[] { "Trace" }, Order: 21)]
-        public int mnum { get; set; }
+        [EnabledIf("AutoSelectChannels", false, HideIfDisabled = true)]
+        [Display("Channel", Description: "Choose which channel to grab data from.", "Measurements", Order: 10)]
+        public List<int> channels { get; set; }
+
+        //[Display("MNum", Groups: new[] { "Trace" }, Order: 21)]
+        //public int mnum { get; set; }
 
         [Display("Ports", Groups: new[] { "Trace" }, Order: 22)]
         public List<int> Ports { get; set; }
@@ -45,33 +49,50 @@ namespace OpenTap.Plugins.PNAX.LMS
 
         public StoreSnp()
         {
-            Channel = 1;
-            mnum = 1;
+            channels = new List<int>() { 1 };
+            //mnum = 1;
             Ports = new List<int>() { 1, 2 };
-            filename = new MacroString(this) { Text = "CH1" };
+            filename = new MacroString(this) { Text = "<PartId>" };
             IsCustomPath = false;
             CustomPath = new MacroString(this) { Text = @"C:\" };
         }
 
         public override void Run()
         {
-            Log.Info("Channel from trace: " + Channel);
-            Log.Info("MNUM from trace: " + mnum);
-
             UpgradeVerdict(Verdict.NotSet);
 
-            string dir = "";
-            if (IsCustomPath)
+            if (AutoSelectChannels)
             {
-                dir = Path.Combine(CustomPath.Expand(PlanRun), filename.Expand(PlanRun) + ".s2p"); ;
-            }
-            else
-            {
-                string assemblyDir = AssemblyDirectory();
-                dir = Path.Combine(assemblyDir, "Results", filename.Expand(PlanRun) + ".s2p");
+                channels = PNAX.GetActiveChannels();
             }
 
-            PNAX.SaveSnP(Channel, mnum, Ports, dir);
+            foreach (int channel in channels)
+            {
+                Log.Info("Storing SNP for Channel : " + channel);
+
+                // Get all measurements for current channel
+                List<int> measurements = PNAX.GetChannelMeasurements(channel);
+
+                Log.Info("MNUMs for channel: " + string.Join<int>(",", measurements));
+
+                string dir = "";
+
+                MacroString macroString = new MacroString(this) { Text = filename.Text + "_CH" + channel };
+                if (IsCustomPath)
+                {
+                    dir = Path.Combine(CustomPath.Expand(PlanRun), macroString.Expand(PlanRun) + ".s2p"); ;
+                }
+                else
+                {
+                    string assemblyDir = AssemblyDirectory();
+                    dir = Path.Combine(assemblyDir, "Results", macroString.Expand(PlanRun) + ".s2p");
+                }
+
+                // Saving to file:
+                Log.Info("Storing SNP to file: " + dir);
+
+                PNAX.SaveSnP(channel, measurements[0], Ports, dir);
+            }
 
             UpgradeVerdict(Verdict.Pass);
         }


### PR DESCRIPTION
Adding Power Meter Calibration
Adding validation of ECAL during headless task. If no ECAL found for any of the enabled connectors then the cal all fails before even starting, this prevents the user to use an incorrect ECAL during calibration.
Close #136 