### PR TITLE
SA Source Error fix

### DIFF
--- a/OpenTap.Plugins.PNAX/Instrument/PNA.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNA.cs
@@ -148,6 +148,8 @@ namespace OpenTap.Plugins.PNAX
 
         private bool IsModelA = false;
 
+        public bool OptionS93088;
+
         public PNAX()
         {
             Name = "PNA-X";
@@ -161,6 +163,8 @@ namespace OpenTap.Plugins.PNAX
             VNAReferenceOut = VNAReferenceFreqEnumtype.Ten;
 
             StoreSnpBlockList = new List<string>() { "Differential I/Q", "Differential IQ" };
+
+            OptionS93088 = true;
         }
 
         /// <summary>
@@ -203,6 +207,13 @@ namespace OpenTap.Plugins.PNAX
             if (isAlwaysPreset)
             {
                 Preset();
+            }
+
+            string[] OPTValues = ScpiQuery("*OPT?").Split(',');
+            OptionS93088 = OPTValues.Any(s => s.Equals("088"));
+            if (!OptionS93088)
+            {
+                Log.Warning("Option S93088A/B not available, SOURce:PHASe commands will be skipped");
             }
 
             if (EnableReferenceOscillatorSettings)

--- a/OpenTap.Plugins.PNAX/Instrument/PNADifferentialIQ.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNADifferentialIQ.cs
@@ -141,6 +141,11 @@ namespace OpenTap.Plugins.PNAX
 
         public void DIQSourceExternalPort(int Channel, string source, int port)
         {
+            if (!OptionS93088)
+            {
+                Log.Warning("Option S93088A/B not on instrument, skipping command: " + $"SOURce{Channel}:PHASe:EXTernal:PORT {port},\"{source}\"");
+                return;
+            }
             ScpiCommand($"SOURce{Channel}:PHASe:EXTernal:PORT {port},\"{source}\"");
         }
         #endregion
@@ -214,11 +219,21 @@ namespace OpenTap.Plugins.PNAX
 
         public void DIQSourcePhaseTolerance(int Channel, string source, double value)
         {
+            if (!OptionS93088)
+            {
+                Log.Warning("Option S93088A/B not on instrument, skipping command: " + $"SOURce{Channel}:PHASe:CONTrol:TOLerance {value},\"{source}\"");
+                return;
+            }
             ScpiCommand($"SOURce{Channel}:PHASe:CONTrol:TOLerance {value},\"{source}\"");
         }
 
         public void DIQSourcePhaseIterations(int Channel, string source, double value)
         {
+            if (!OptionS93088)
+            {
+                Log.Warning("Option S93088A/B not on instrument, skipping command: " + $"SOURce{Channel}:PHASe:CONTrol:ITERation {value},\"{source}\"");
+                return;
+            }
             ScpiCommand($"SOURce{Channel}:PHASe:CONTrol:ITERation {value},\"{source}\"");
         }
         #endregion

--- a/OpenTap.Plugins.PNAX/Instrument/PNASpectrumAnalyzer.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNASpectrumAnalyzer.cs
@@ -427,31 +427,61 @@ namespace OpenTap.Plugins.PNAX
 
         public double GetSAPhaseStart(int Channel, string src)
         {
+            if (!OptionS93088)
+            {
+                Log.Warning("Option S93088A/B not on instrument, skipping command: " + $"SOURce{ Channel }:PHASe:STARt? \"{src}\"");
+                return double.NaN;
+            }
             return ScpiQuery<double>($"SOURce{ Channel }:PHASe:STARt? \"{src}\"");
         }
 
         public void SetSAPhaseStart(int Channel, string src, double freq)
         {
+            if (!OptionS93088)
+            {
+                Log.Warning("Option S93088A/B not on instrument, skipping command: " + $"SOURce{ Channel }:PHASe:STARt { freq },\"{src}\"");
+                return;
+            }
             ScpiCommand($"SOURce{ Channel }:PHASe:STARt { freq },\"{src}\"");
         }
 
         public double GetSAPhaseStop(int Channel, string src)
         {
+            if (!OptionS93088)
+            {
+                Log.Warning("Option S93088A/B not on instrument, skipping command: " + $"SOURce{ Channel }:PHASe:STOP? \"{src}\"");
+                return double.NaN;
+            }
             return ScpiQuery<double>($"SOURce{ Channel }:PHASe:STOP? \"{src}\""); ;
         }
 
         public void SetSAPhaseStop(int Channel, string src, double freq)
         {
+            if (!OptionS93088)
+            {
+                Log.Warning("Option S93088A/B not on instrument, skipping command: " + $"SOURce{ Channel }:PHASe:STOP { freq },\"{src}\"");
+                return;
+            }
             ScpiCommand($"SOURce{ Channel }:PHASe:STOP { freq },\"{src}\"");
         }
 
         public double GetSAPhaseLevel(int Channel, string src)
         {
+            if (!OptionS93088)
+            {
+                Log.Warning("Option S93088A/B not on instrument, skipping command: " + $"SOURce{ Channel }:PHASe:FIXed? \"{src}\"");
+                return double.NaN;
+            }
             return ScpiQuery<double>($"SOURce{ Channel }:PHASe:FIXed? \"{src}\"");
         }
 
         public void SetSAPhaseLevel(int Channel, string src, double freq)
         {
+            if (!OptionS93088)
+            {
+                Log.Warning("Option S93088A/B not on instrument, skipping command: " + $"SOURce{ Channel }:PHASe:FIXed { freq },\"{src}\"");
+                return;
+            }
             ScpiCommand($"SOURce{ Channel }:PHASe:FIXed { freq },\"{src}\"");
         }
 

--- a/OpenTap.Plugins.PNAX/Instrument/PNAStandard.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNAStandard.cs
@@ -158,21 +158,41 @@ namespace OpenTap.Plugins.PNAX
 
         public double GetPhaseStart(int Channel)
         {
+            if (!OptionS93088)
+            {
+                Log.Warning("Option S93088A/B not on instrument, skipping command: " + $"SOURce{ Channel }:PHASe:STARt?");
+                return double.NaN;
+            }
             return ScpiQuery<double>($"SOURce{ Channel }:PHASe:STARt?"); ;
         }
 
         public void SetPhaseStart(int Channel, double phase)
         {
+            if (!OptionS93088)
+            {
+                Log.Warning("Option S93088A/B not on instrument, skipping command: " + $"SOURce{ Channel }:PHASe:STARt { phase }");
+                return;
+            }
             ScpiCommand($"SOURce{ Channel }:PHASe:STARt { phase }");
         }
 
         public double GetPhaseStop(int Channel)
         {
+            if (!OptionS93088)
+            {
+                Log.Warning("Option S93088A/B not on instrument, skipping command: " + $"SOURce{ Channel }:PHASe:STOP?");
+                return double.NaN;
+            }
             return ScpiQuery<double>($"SOURce{ Channel }:PHASe:STOP?"); ;
         }
 
         public void SetPhaseStop(int Channel, double phase)
         {
+            if (!OptionS93088)
+            {
+                Log.Warning("Option S93088A/B not on instrument, skipping command: " + $"SOURce{ Channel }:PHASe:STOP { phase }");
+                return;
+            }
             ScpiCommand($"SOURce{ Channel }:PHASe:STOP { phase }");
         }
         #endregion


### PR DESCRIPTION
Querying options during Instrument.Open() and updating instrument property OptionS93088

Updated every SCPI command that makes use of SOURce:PHASe to log a warning to the user that the command was not sent

close #149 