### PR TITLE
164 add support for ssa x instrument

### DIFF
--- a/.gitversion
+++ b/.gitversion
@@ -3,7 +3,7 @@
 
 # This is the version number that will be used. Prerelease numbers are calculated by 
 # counting git commits since the last change in this value.
-version = 0.6.4
+version = 0.6.5
 
 # A version is determined to be a "beta" prerelease if it originates from the default branch
 # The default branch is the first branch that matches the following regular expession.

--- a/OpenTap.Plugins.PNAX/Instrument/PNA.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNA.cs
@@ -146,7 +146,7 @@ namespace OpenTap.Plugins.PNAX
 
         public GeneralGainCompressionPowerValues DefaultGeneralGainCompressionPowerValues;
 
-        private bool IsModelA = false;
+        protected bool IsModelA = false;
 
         public bool OptionS93088;
 
@@ -222,6 +222,30 @@ namespace OpenTap.Plugins.PNAX
             {
                 SetReferenceIn(VNAReferenceIn);
                 SetVNAOutputReferenceOscillatorFrequency(VNAReferenceOut);
+            }
+        }
+
+        public void Open(bool InitSSAX)
+        {
+            if (InitSSAX)
+            {
+                base.Open();
+                IsModelA = false;
+                OptionS93088 = false;
+
+                if (isAlwaysPreset)
+                {
+                    Preset();
+                }
+                if (EnableReferenceOscillatorSettings)
+                {
+                    SetReferenceIn(VNAReferenceIn);
+                    SetVNAOutputReferenceOscillatorFrequency(VNAReferenceOut);
+                }
+            }
+            else
+            {
+                Open();
             }
         }
 

--- a/OpenTap.Plugins.PNAX/Instrument/PNA.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNA.cs
@@ -516,5 +516,24 @@ namespace OpenTap.Plugins.PNAX
         {
             return ScpiQuery<bool>("SYSTem:COMMunicate:DRIVe:ENABle?");
         }
+
+        /// <summary>
+        /// Finds all Windows
+        /// </summary>
+        public List<int> GetActiveWindows()
+        {
+            var windows = ScpiQuery("DISPlay:CATalog?");
+
+            // Clean string
+            char[] charsToTrim = { '"', '\n' };
+            var activeWindows = windows.Trim(charsToTrim).Split(',').Select(int.Parse).ToList();
+            return activeWindows;
+        }
+
+        public void AutoScaleWindow(int wnum)
+        {
+            ScpiCommand($"DISPlay:WINDow{wnum}:Y:AUTO");
+        }
+
     }
 }

--- a/OpenTap.Plugins.PNAX/Network Analyzer Steps/AutoScale.cs
+++ b/OpenTap.Plugins.PNAX/Network Analyzer Steps/AutoScale.cs
@@ -1,12 +1,11 @@
 ﻿using OpenTap;
-using OpenTap.Plugins.PNAX;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Text;
 
-namespace Signal_Source_Analyzer
+namespace OpenTap.Plugins.PNAX
 {
     [Display("Auto Scale", Groups: new[] { "Network Analyzer" }, Description: "Auto scale window")]
     public class AutoScale : TestStep

--- a/OpenTap.Plugins.PNAX/Network Analyzer Steps/AutoScale.cs
+++ b/OpenTap.Plugins.PNAX/Network Analyzer Steps/AutoScale.cs
@@ -1,0 +1,64 @@
+﻿using OpenTap;
+using OpenTap.Plugins.PNAX;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace Signal_Source_Analyzer
+{
+    [Display("Auto Scale", Groups: new[] { "Network Analyzer" }, Description: "Auto scale window")]
+    public class AutoScale : TestStep
+    {
+        #region Settings
+        [Display("PNA", Order: 0.1)]
+        public PNAX PNAX { get; set; }
+
+        [Display("Auto Select All Windows", Group: "Measurements", Order: 1)]
+        public bool AutoSelectWindows { get; set; }
+
+        [EnabledIf("AutoSelectWindows", false, HideIfDisabled = true)]
+        [Display("Windows", Description: "Choose which channels to trigger.", "Measurements", Order: 2)]
+        public List<int> windows { get; set; }
+        #endregion
+
+        public AutoScale()
+        {
+            windows = new List<int>() { 1 };
+            AutoSelectWindows = true;
+        }
+
+        public void AutoSelectChannelsAvailableOnInstrument()
+        {
+            if (AutoSelectWindows)
+            {
+                windows = PNAX.GetActiveWindows();
+            }
+        }
+
+        public override void Run()
+        {
+            UpgradeVerdict(Verdict.NotSet);
+            AutoSelectChannelsAvailableOnInstrument();
+
+            try
+            {
+                foreach (int window in windows)
+                {
+                    PNAX.AutoScaleWindow(window);
+                }
+            }
+            catch (IndexOutOfRangeException ex)
+            {
+                throw ex;
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+
+            UpgradeVerdict(Verdict.Pass);
+        }
+    }
+}


### PR DESCRIPTION
Updated Store Trace Data to have option to enable/disable rounding of Frequency and Data columns. For SSA-X some traces are using time for the X axis and the time is usually in the microseconds, rounding these values was giving a value of 0.
Added Instrument Open for SSA-X which does not have A Models
Updated IsModelA private to protected so it can be updated in SSA-X instrument
Adding Auto Scale Test Step