### PR TITLE
211 bugfix 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,4 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+.vscode/settings.json

--- a/.gitversion
+++ b/.gitversion
@@ -3,7 +3,7 @@
 
 # This is the version number that will be used. Prerelease numbers are calculated by 
 # counting git commits since the last change in this value.
-version = 0.7.4
+version = 0.7.5
 
 # A version is determined to be a "beta" prerelease if it originates from the default branch
 # The default branch is the first branch that matches the following regular expession.

--- a/OpenTap.Plugins.PNAX/Converters/Mixer Steps/MixerFrequencyTestStep.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Mixer Steps/MixerFrequencyTestStep.cs
@@ -489,6 +489,7 @@ namespace OpenTap.Plugins.PNAX
 
                 // Set requirements
                 PNAX.SetConverterStages(DummyChannel, ConverterStages);
+                SetMultiplier(DummyChannel);
                 //SetInput();
                 SetLO1(DummyChannel);
                 SetIF(DummyChannel);
@@ -504,8 +505,8 @@ namespace OpenTap.Plugins.PNAX
                 if (inpMode.Equals("SWEPT"))
                 {
                     InputMixerFrequencyType = MixerFrequencyTypeEnum.StartStop;
-                    double ReadStart = PNAX.GetFrequencyLOStart(DummyChannel, 1);
-                    double ReadStop = PNAX.GetFrequencyLOStop(DummyChannel, 1);
+                    double ReadStart = PNAX.GetFrequencyInputStart(DummyChannel);
+                    double ReadStop = PNAX.GetFrequencyInputStop(DummyChannel);
                     InputMixerFrequencyStart = ReadStart;
                     InputMixerFrequencyStop = ReadStop;
                 }

--- a/OpenTap.Plugins.PNAX/Converters/Mixer Steps/MixerFrequencyTestStep.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Mixer Steps/MixerFrequencyTestStep.cs
@@ -104,8 +104,13 @@ namespace OpenTap.Plugins.PNAX
         [Unit("Hz", UseEngineeringPrefix: true)]
         public double InputMixerFrequencyFixed { get; set; }
 
+        [Display("Fractional Multiplier Numerator", Groups: new[] { "Mixer Frequency", "Input" }, Order: 16)]
+        public int InputFractionalMultiplierNumerator { get; set; }
+        [Display("Fractional Multiplier Denominator", Groups: new[] { "Mixer Frequency", "Input" }, Order: 17)]
+        public int InputFractionalMultiplierDenominator { get; set; }
+
         [Browsable(true)]
-        [Display("Calc Input", Groups: new[] { "Mixer Frequency", "Input" }, Order: 16)]
+        [Display("Calc Input", Groups: new[] { "Mixer Frequency", "Input" }, Order: 18)]
         public void CalcInput()
         {
             if (PNAX.IsConnected)
@@ -117,6 +122,7 @@ namespace OpenTap.Plugins.PNAX
         }
 
         #endregion
+
 
         #region LO1
         [Browsable(false)]
@@ -186,8 +192,13 @@ namespace OpenTap.Plugins.PNAX
         [Display("Input > LO", Groups: new[] { "Mixer Frequency", "LO1" }, Order: 26)]
         public bool InputGTLO1 { get; set; }
 
+        [Display("Fractional Multiplier Numerator", Groups: new[] { "Mixer Frequency", "LO1" }, Order: 27)]
+        public int LO1FractionalMultiplierNumerator { get; set; }
+        [Display("Fractional Multiplier Denominator", Groups: new[] { "Mixer Frequency", "LO1" }, Order: 28)]
+        public int LO1FractionalMultiplierDenominator { get; set; }
+
         [Browsable(true)]
-        [Display("Calc LO", Groups: new[] { "Mixer Frequency", "LO1" }, Order: 27)]
+        [Display("Calc LO", Groups: new[] { "Mixer Frequency", "LO1" }, Order: 29)]
         public void CalcLO1()
         {
             if (PNAX.IsConnected)
@@ -351,9 +362,17 @@ namespace OpenTap.Plugins.PNAX
         [EnabledIf("DoubleStage", true, HideIfDisabled = true)]
         public bool IF1GTLO2 { get; set; }
 
+
+        [Display("Fractional Multiplier Numerator", Groups: new[] { "Mixer Frequency", "LO2" }, Order: 47)]
+        [EnabledIf("DoubleStage", true, HideIfDisabled = true)]
+        public int LO2FractionalMultiplierNumerator { get; set; }
+        [Display("Fractional Multiplier Denominator", Groups: new[] { "Mixer Frequency", "LO2" }, Order: 48)]
+        [EnabledIf("DoubleStage", true, HideIfDisabled = true)]
+        public int LO2FractionalMultiplierDenominator { get; set; }
+
         [Browsable(true)]
         [EnabledIf("DoubleStage", true, HideIfDisabled = true)]
-        [Display("Calc LO2", Groups: new[] { "Mixer Frequency", "LO2" }, Order: 47)]
+        [Display("Calc LO2", Groups: new[] { "Mixer Frequency", "LO2" }, Order: 49)]
         public void CalcLO2()
         {
             if (PNAX.IsConnected)
@@ -533,12 +552,12 @@ namespace OpenTap.Plugins.PNAX
                 // Set requirements
                 PNAX.SetConverterStages(DummyChannel, ConverterStages);
                 SetInput(DummyChannel);
+                SetMultiplier(DummyChannel);
                 //SetLO1();
                 SetIF(DummyChannel);
                 SetLO2(DummyChannel);
                 SetOutput(DummyChannel);
 
-                //PNAX.MixerApply(DummyChannel);
                 PNAX.MixerCalc(DummyChannel, "LO_1");
                 PNAX.WaitForOperationComplete();
 
@@ -600,8 +619,8 @@ namespace OpenTap.Plugins.PNAX
                 PNAX.SetConverterStages(DummyChannel, ConverterStages);
                 SetInput(DummyChannel);
                 SetLO1(DummyChannel);
+                SetMultiplier(DummyChannel);
                 SetIF(DummyChannel);
-                //SetLO2(DummyChannel);
                 SetOutput(DummyChannel);
 
                 PNAX.MixerCalc(DummyChannel, "LO_2");
@@ -664,6 +683,7 @@ namespace OpenTap.Plugins.PNAX
                 // Set requirements
                 PNAX.SetConverterStages(DummyChannel, ConverterStages);
                 SetInput(DummyChannel);
+                SetMultiplier(DummyChannel);
                 SetLO1(DummyChannel);
                 SetIF(DummyChannel);
                 SetLO2(DummyChannel);
@@ -720,7 +740,8 @@ namespace OpenTap.Plugins.PNAX
         private void UpdateDefaultValues()
         {
             var defaultValues = PNAX.GetMixerFrequencyDefaultValues();
-            if (defaultValues == null)
+            var defaultSettings = PNAX.GetMixerSetupDefaultValues();
+            if (defaultValues == null || defaultSettings == null)
                 return;
 
             InputMixerFrequencyType = defaultValues.InputMixerFrequencyType;
@@ -729,6 +750,8 @@ namespace OpenTap.Plugins.PNAX
             InputMixerFrequencyCenter = defaultValues.InputMixerFrequencyCenter;
             InputMixerFrequencySpan = defaultValues.InputMixerFrequencySpan;
             InputMixerFrequencyFixed = defaultValues.InputMixerFrequencyFixed;
+            InputFractionalMultiplierNumerator = defaultSettings.InputFractionalMultiplierNumerator;
+            InputFractionalMultiplierDenominator = defaultSettings.InputFractionalMultiplierDenominator;
 
             LO1MixerFrequencyType = defaultValues.LO1MixerFrequencyType;
             LO1MixerFrequencyStart = defaultValues.LO1MixerFrequencyStart;
@@ -737,6 +760,8 @@ namespace OpenTap.Plugins.PNAX
             LO1MixerFrequencySpan = defaultValues.LO1MixerFrequencySpan;
             LO1MixerFrequencyFixed = defaultValues.LO1MixerFrequencyFixed;
             InputGTLO1 = defaultValues.InputGTLO1;
+            LO1FractionalMultiplierNumerator = defaultSettings.LO1FractionalMultiplierNumerator;
+            LO1FractionalMultiplierDenominator = defaultSettings.LO1FractionalMultiplierDenominator;
 
             IFSidebandType = defaultValues.IFSidebandType;
             IFMixerFrequencyType = defaultValues.IFMixerFrequencyType;
@@ -753,6 +778,8 @@ namespace OpenTap.Plugins.PNAX
             LO2MixerFrequencySpan = defaultValues.LO2MixerFrequencySpan;
             LO2MixerFrequencyFixed = defaultValues.LO2MixerFrequencyFixed;
             IF1GTLO2 = defaultValues.IF1GTLO2;
+            LO2FractionalMultiplierNumerator = defaultSettings.LO2FractionalMultiplierNumerator;
+            LO2FractionalMultiplierDenominator = defaultSettings.LO2FractionalMultiplierDenominator;
 
             OutputSidebandType = defaultValues.OutputSidebandType;
             OutputMixerFrequencyType = defaultValues.OutputMixerFrequencyType;
@@ -776,6 +803,7 @@ namespace OpenTap.Plugins.PNAX
             PNAX.SetConverterStages(Channel, ConverterStages);
 
             SetInput(Channel);
+            SetMultiplier(Channel);
             SetLO1(Channel);
             SetIF(Channel);
             SetLO2(Channel);
@@ -913,6 +941,19 @@ namespace OpenTap.Plugins.PNAX
             #endregion
 
             UpgradeVerdict(Verdict.Pass);
+        }
+
+        private void SetMultiplier(int Channel)
+        {
+            PNAX.SetInputFractionalMultiplierNumerator(Channel, InputFractionalMultiplierNumerator);
+            PNAX.SetInputFractionalMultiplierDenominator(Channel, InputFractionalMultiplierDenominator);
+            PNAX.SetLOFractionalMultiplierNumerator(Channel, 1, LO1FractionalMultiplierNumerator);
+            PNAX.SetLOFractionalMultiplierDenominator(Channel, 1, LO1FractionalMultiplierDenominator);
+            if (ConverterStages == ConverterStagesEnum._2)
+            {
+                PNAX.SetLOFractionalMultiplierNumerator(Channel, 2, LO2FractionalMultiplierNumerator);
+                PNAX.SetLOFractionalMultiplierDenominator(Channel, 2, LO2FractionalMultiplierDenominator);
+            }
         }
 
         private void SetInput(int Channel)

--- a/OpenTap.Plugins.PNAX/Converters/Mixer Steps/MixerFrequencyTestStep.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Mixer Steps/MixerFrequencyTestStep.cs
@@ -950,10 +950,17 @@ namespace OpenTap.Plugins.PNAX
             PNAX.SetInputFractionalMultiplierDenominator(Channel, InputFractionalMultiplierDenominator);
             PNAX.SetLOFractionalMultiplierNumerator(Channel, 1, LO1FractionalMultiplierNumerator);
             PNAX.SetLOFractionalMultiplierDenominator(Channel, 1, LO1FractionalMultiplierDenominator);
+
+            retVal.Add(("Fractional Multiplier Numerator", InputFractionalMultiplierNumerator));
+            retVal.Add(("Fractional Multiplier Denominator", InputFractionalMultiplierDenominator));
+            retVal.Add(("LO1 Fractional Multiplier Numerator", LO1FractionalMultiplierNumerator));
+            retVal.Add(("LO1 Fractional Multiplier Denominator", LO1FractionalMultiplierDenominator));
             if (ConverterStages == ConverterStagesEnum._2)
             {
                 PNAX.SetLOFractionalMultiplierNumerator(Channel, 2, LO2FractionalMultiplierNumerator);
                 PNAX.SetLOFractionalMultiplierDenominator(Channel, 2, LO2FractionalMultiplierDenominator);
+                retVal.Add(("LO2 Fractional Multiplier Numerator", LO2FractionalMultiplierNumerator));
+                retVal.Add(("LO2 Fractional Multiplier Denominator", LO2FractionalMultiplierDenominator));
             }
         }
 

--- a/OpenTap.Plugins.PNAX/Converters/Mixer Steps/MixerSetupTestStep.cs
+++ b/OpenTap.Plugins.PNAX/Converters/Mixer Steps/MixerSetupTestStep.cs
@@ -118,26 +118,6 @@ namespace OpenTap.Plugins.PNAX
             }
         }
 
-        [Display("Fractional Multiplier Numerator", Group: "Input Port", Order: 31)]
-        public int InputFractionalMultiplierNumerator { get; set; }
-        [Display("Fractional Multiplier Denominator", Group: "Input Port", Order: 32)]
-        public int InputFractionalMultiplierDenominator { get; set; }
-
-        [Display("Fractional Multiplier Numerator", Group: "LO1 Port", Order: 41)]
-        public int LO1FractionalMultiplierNumerator { get; set; }
-        [Display("Fractional Multiplier Denominator", Group: "LO1 Port", Order: 42)]
-        public int LO1FractionalMultiplierDenominator { get; set; }
-
-        [Display("Fractional Multiplier Numerator", Group: "LO2 Port", Order: 51)]
-        [EnabledIf("DoubleStage", true, HideIfDisabled = true)]
-        public int LO2FractionalMultiplierNumerator { get; set; }
-        [Display("Fractional Multiplier Denominator", Group: "LO2 Port", Order: 52)]
-        [EnabledIf("DoubleStage", true, HideIfDisabled = true)]
-        public int LO2FractionalMultiplierDenominator { get; set; }
-
-
-
-
 
         [Display("Enable Embedded LO", Group: "Embedded LO", Order: 70)]
         public bool EnableEmbeddedLO { get; set; }
@@ -237,12 +217,6 @@ namespace OpenTap.Plugins.PNAX
             PortOutput = defaultValues.PortOutput;
             PortLO1 = defaultValues.PortLO1;
             PortLO2 = defaultValues.PortLO2;
-            InputFractionalMultiplierNumerator = defaultValues.InputFractionalMultiplierNumerator;
-            InputFractionalMultiplierDenominator = defaultValues.InputFractionalMultiplierDenominator;
-            LO1FractionalMultiplierNumerator = defaultValues.LO1FractionalMultiplierNumerator;
-            LO1FractionalMultiplierDenominator = defaultValues.LO1FractionalMultiplierDenominator;
-            LO2FractionalMultiplierNumerator = defaultValues.LO2FractionalMultiplierNumerator;
-            LO2FractionalMultiplierDenominator = defaultValues.LO2FractionalMultiplierDenominator;
 
             EnableEmbeddedLO = defaultValues.EnableEmbeddedLO;
             TuningMethod = defaultValues.TuningMethod;
@@ -262,15 +236,9 @@ namespace OpenTap.Plugins.PNAX
 
             PNAX.SetConverterStages(Channel, ConverterStages);
             PNAX.SetPortInputOutput(Channel, PortInput, PortOutput);
-            PNAX.SetInputFractionalMultiplierNumerator(Channel, InputFractionalMultiplierNumerator);
-            PNAX.SetInputFractionalMultiplierDenominator(Channel, InputFractionalMultiplierDenominator);
-            PNAX.SetLOFractionalMultiplierNumerator(Channel, 1, LO1FractionalMultiplierNumerator);
-            PNAX.SetLOFractionalMultiplierDenominator(Channel, 1, LO1FractionalMultiplierDenominator);
             PNAX.SetPortLO(Channel, 1, PortLO1);
             if (ConverterStages == ConverterStagesEnum._2)
             {
-                PNAX.SetLOFractionalMultiplierNumerator(Channel, 2, LO2FractionalMultiplierNumerator);
-                PNAX.SetLOFractionalMultiplierDenominator(Channel, 2, LO2FractionalMultiplierDenominator);
                 PNAX.SetPortLO(Channel, 2, PortLO2);
             }
 
@@ -298,15 +266,9 @@ namespace OpenTap.Plugins.PNAX
             {
                 ("Converter Stages", ConverterStages),
                 ("Input Port", PortInput),
-                ("Fractional Multiplier Numerator", InputFractionalMultiplierNumerator),
-                ("Fractional Multiplier Denominator", InputFractionalMultiplierDenominator),
-                ("LO1 Fractional Multiplier Numerator", LO1FractionalMultiplierNumerator),
-                ("LO1 Fractional Multiplier Denominator", LO1FractionalMultiplierDenominator)
             };
             if (ConverterStages == ConverterStagesEnum._2)
             {
-                retVal.Add(("LO2 Fractional Multiplier Numerator", LO2FractionalMultiplierNumerator));
-                retVal.Add(("LO2 Fractional Multiplier Denominator", LO2FractionalMultiplierDenominator));
                 retVal.Add(("LO2 Port", PortLO2));
             }
             retVal.Add(("Enable Embedded LO", EnableEmbeddedLO));


### PR DESCRIPTION
Move input, Lo1, lo2 numerator and denominator from mixerSetup step to MixerFrequency step.
According our VNA experts, the original design to put those numerators and denominators are only for frequencies, but not setup.
Now we can apply those multipliers in frequency calculation step, which fix the bug.