### PR TITLE
Multiple NullReferenceException fixes and improved error handling

### DIFF
--- a/OpenTap.Plugins.PNAX/Acquisition/StoreSnp.cs
+++ b/OpenTap.Plugins.PNAX/Acquisition/StoreSnp.cs
@@ -59,14 +59,15 @@ namespace OpenTap.Plugins.PNAX.LMS
             Log.Info("Channel from trace: " + Channel);
             Log.Info("MNUM from trace: " + mnum);
 
-            SingleTraceBaseStep x = (mnum.Step as SingleTraceBaseStep);
-
-            Log.Info("trace Window: ");
-            Log.Info("trace Window: " + x.Window);
-            Log.Info("trace Sheet: " + x.Sheet);
-            Log.Info("trace tnum: " + x.tnum);
-            Log.Info("trace mnum: " + x.mnum);
-            Log.Info("trace MeasName: " + x.MeasName);
+            if (mnum.Step is SingleTraceBaseStep x)
+            {
+                Log.Info("trace Window: ");
+                Log.Info("trace Window: " + x.Window);
+                Log.Info("trace Sheet: " + x.Sheet);
+                Log.Info("trace tnum: " + x.tnum);
+                Log.Info("trace mnum: " + x.mnum);
+                Log.Info("trace MeasName: " + x.MeasName);
+            }
 
             UpgradeVerdict(Verdict.NotSet);
 

--- a/OpenTap.Plugins.PNAX/General/Standard/SweepType.cs
+++ b/OpenTap.Plugins.PNAX/General/Standard/SweepType.cs
@@ -160,6 +160,9 @@ namespace OpenTap.Plugins.PNAX
 
         private void UpdateDefaultValues()
         {
+            if (PNAX == null)
+                return;
+
             var defaultValues = PNAX.GetStandardChannelDefaultValues();
             StandardSweepType = defaultValues.SweepType;
             SweepPropertiesStart = defaultValues.Start;

--- a/OpenTap.Plugins.PNAX/General/Standard/Timing.cs
+++ b/OpenTap.Plugins.PNAX/General/Standard/Timing.cs
@@ -85,6 +85,9 @@ namespace OpenTap.Plugins.PNAX
 
         private void UpdateDefaultValues()
         {
+            if (PNAX == null)
+                return;
+
             var defaultValues = PNAX.GetStandardChannelDefaultValues();
             _SweepTimeAuto = defaultValues.SweepTimeAuto;
             _SweepTimeStepped = defaultValues.SweepTimeStepped;

--- a/OpenTap.Plugins.PNAX/Instrument/PNA.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNA.cs
@@ -401,28 +401,7 @@ namespace OpenTap.Plugins.PNAX
             return TraceCount++;
         }
 
-        public override void ScpiCommand(string command)
-        {
-            base.ScpiCommand(command);
-
-            if (IsWaitForOpc)
-            {
-                WaitForOperationComplete();
-            }
-
-            if (IsQueryForErrors)
-            {
-                List<ScpiError> errors = base.QueryErrors();
-
-                if (errors.Count > 0)
-                {
-                    string errorString = string.Join(",", errors.ToArray());
-                    throw new Exception($"Error: {errorString} while sending command: {command}");
-                }
-            }
-        }
-
-        public void ScpiCommand(string command, int timeOut)
+        public void ScpiCommand(string command, int timeOut = 2000)
         {
             base.ScpiCommand(command);
 
@@ -431,23 +410,35 @@ namespace OpenTap.Plugins.PNAX
                 WaitForOperationComplete(timeOut);
             }
 
-            if (IsQueryForErrors)
-            {
-                List<ScpiError> errors = base.QueryErrors();
-
-                if (errors.Count > 0)
-                {
-                    string errorString = string.Join(",", errors.ToArray());
-                    throw new Exception($"Error: {errorString} while sending command: {command}");
-                }
-            }
+            QueryForErrors(command);
         }
 
         public override string ScpiQuery(string query, bool isSilent = false)
         {
-            string strRet = base.ScpiQuery(query, isSilent);
-            strRet = strRet.Replace("\n", "");
-            return strRet;
+            try
+            {
+                string strRet = base.ScpiQuery(query, isSilent);
+                strRet = strRet.Replace("\n", "");
+                return strRet;
+            }
+            catch (Exception)
+            {
+                QueryForErrors(query);
+                throw;
+            }
+        }
+
+        private void QueryForErrors(string command)
+        {
+            if (!IsQueryForErrors)
+                return;
+
+            List<ScpiError> errors = QueryErrors();
+            if (errors.Count <= 0)
+                return;
+
+            string errorString = string.Join(",", errors.ToArray());
+            Log.Error($"Error: {errorString} while sending command: {command}");
         }
 
         public void SetTriggerSource(TriggerSourceEnumType trigerSource)

--- a/OpenTap.Plugins.PNAX/Instrument/PNALoadMeasStore.cs
+++ b/OpenTap.Plugins.PNAX/Instrument/PNALoadMeasStore.cs
@@ -1,7 +1,5 @@
-﻿using OpenTap;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -708,7 +706,10 @@ namespace OpenTap.Plugins.PNAX
             }
             catch (Exception ex)
             {
-                throw ex;
+                if (ex is TimeoutException)
+                    Log.Error("Failed to change folder. Please ensure that 'Enable Remote Drive Access' is enabled in System -> System Setup -> Remote Interface.");
+
+                throw;
             }
 
         }


### PR DESCRIPTION
Fixes #47 

This PR fixes the following:
- `NullReferenceException` when a PNA instrument is not already added when loading a test plan that depends on this plugin
- `NullReferenceException` in StoreSnp when no MNUM is `None`
- Merge of `ScpiCommand(string command)` and `ScpiCommand(string command, int timeOut)` as they were basically identical
- Run `QueryErrors` for both `ScpiCommand` and `ScpiQuery` if enabled in Instrument Settings.
- Give a possible explanation of why `ChangeFolders` could fail with a timeout